### PR TITLE
Added new range helpers for generating more usable trees for displaying

### DIFF
--- a/__tests__/range.tests.ts
+++ b/__tests__/range.tests.ts
@@ -1,0 +1,578 @@
+import tableOfContentManifests from '../fixtures/cookbook/toc.json';
+import {
+  Vault,
+  getValue,
+  rangeToTableOfContentsTree,
+  rangesToTableOfContentsTree,
+  RangeTableOfContentsNode,
+} from '../src';
+import { ManifestNormalized } from '@iiif/presentation-3-normalized';
+import tableOfContentsAvManifest from '../fixtures/cookbook/toc-av.json';
+import wellcomeRange from '../fixtures/presentation-2/wellcome-range.json';
+import blManifest from '../fixtures/presentation-3/bl-av-manifest.json';
+import invariant from 'tiny-invariant';
+
+// Test utility.
+// Render range in ascii with children + indentation.
+const treeChars = {
+  vertical: '│',
+  horizontal: '─',
+  corner: '└',
+  tee: '├',
+  space: ' ',
+};
+
+function renderRange(range: RangeTableOfContentsNode | null, skipCanvases = false, indent = 0) {
+  if (!range) {
+    return '';
+  }
+  const spaces = treeChars.space.repeat(indent);
+  let str = `${getValue(range.label)}\n`;
+  const itemsCount = range.items ? range.items.length : 0;
+  range.items?.forEach((item, index) => {
+    const isLastItem = index === itemsCount - 1;
+    if (item.isCanvasLeaf && skipCanvases) return;
+    if (typeof item === 'string') {
+      str += `${spaces}${isLastItem ? treeChars.corner : treeChars.tee}${treeChars.horizontal}${treeChars.horizontal} ${item}\n`;
+    } else {
+      str += `${spaces}${isLastItem ? treeChars.corner : treeChars.tee}${treeChars.horizontal}${treeChars.horizontal} ${renderRange(item, skipCanvases, indent + 2)}`;
+    }
+  });
+  return str;
+}
+
+describe('range helper', () => {
+  describe('rangeToTableOfContentsTree', () => {
+    test('it can make a table of contents tree', () => {
+      const vault = new Vault();
+      const manifest = vault.loadSync<ManifestNormalized>(tableOfContentManifests.id, tableOfContentManifests);
+
+      invariant(manifest);
+
+      const tree = rangeToTableOfContentsTree(vault, manifest.structures[0] as any);
+
+      expect(renderRange(tree)).toMatchInlineSnapshot(`
+        "Table of Contents
+        ├── Tabiba Tabiban [ጠቢበ ጠቢባን]
+          ├── f. 1r
+          └── f. 1v
+        └── Arede'et [አርድዕት]
+          ├── Monday
+            ├── f. 2r
+            └── f. 2v
+          └── Tuesday
+            ├── f. 3r
+            └── f. 3v
+        "
+      `);
+      //todo
+      expect(tree).toMatchInlineSnapshot(`
+        {
+          "firstCanvas": {
+            "selector": undefined,
+            "source": {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+              "type": "Canvas",
+            },
+            "type": "SpecificResource",
+          },
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r0",
+          "isCanvasLeaf": false,
+          "isRangeLeaf": false,
+          "items": [
+            {
+              "firstCanvas": {
+                "selector": undefined,
+                "source": {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+                  "type": "Canvas",
+                },
+                "type": "SpecificResource",
+              },
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r1",
+              "isCanvasLeaf": false,
+              "isRangeLeaf": true,
+              "items": [
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+                  "isCanvasLeaf": true,
+                  "isRangeLeaf": false,
+                  "label": {
+                    "en": [
+                      "f. 1r",
+                    ],
+                  },
+                  "resource": {
+                    "selector": undefined,
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "type": "Canvas",
+                  "untitled": false,
+                },
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
+                  "isCanvasLeaf": true,
+                  "isRangeLeaf": false,
+                  "label": {
+                    "en": [
+                      "f. 1v",
+                    ],
+                  },
+                  "resource": {
+                    "selector": undefined,
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "type": "Canvas",
+                  "untitled": false,
+                },
+              ],
+              "label": {
+                "gez": [
+                  "Tabiba Tabiban [ጠቢበ ጠቢባን]",
+                ],
+              },
+              "type": "Range",
+              "untitled": false,
+            },
+            {
+              "firstCanvas": {
+                "selector": undefined,
+                "source": {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+                  "type": "Canvas",
+                },
+                "type": "SpecificResource",
+              },
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2",
+              "isCanvasLeaf": false,
+              "isRangeLeaf": false,
+              "items": [
+                {
+                  "firstCanvas": {
+                    "selector": undefined,
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2/1",
+                  "isCanvasLeaf": false,
+                  "isRangeLeaf": true,
+                  "items": [
+                    {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+                      "isCanvasLeaf": true,
+                      "isRangeLeaf": false,
+                      "label": {
+                        "en": [
+                          "f. 2r",
+                        ],
+                      },
+                      "resource": {
+                        "selector": undefined,
+                        "source": {
+                          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+                          "type": "Canvas",
+                        },
+                        "type": "SpecificResource",
+                      },
+                      "type": "Canvas",
+                      "untitled": false,
+                    },
+                    {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4",
+                      "isCanvasLeaf": true,
+                      "isRangeLeaf": false,
+                      "label": {
+                        "en": [
+                          "f. 2v",
+                        ],
+                      },
+                      "resource": {
+                        "selector": undefined,
+                        "source": {
+                          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4",
+                          "type": "Canvas",
+                        },
+                        "type": "SpecificResource",
+                      },
+                      "type": "Canvas",
+                      "untitled": false,
+                    },
+                  ],
+                  "label": {
+                    "en": [
+                      "Monday",
+                    ],
+                  },
+                  "type": "Range",
+                  "untitled": false,
+                },
+                {
+                  "firstCanvas": {
+                    "selector": undefined,
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2/2",
+                  "isCanvasLeaf": false,
+                  "isRangeLeaf": true,
+                  "items": [
+                    {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+                      "isCanvasLeaf": true,
+                      "isRangeLeaf": false,
+                      "label": {
+                        "en": [
+                          "f. 3r",
+                        ],
+                      },
+                      "resource": {
+                        "selector": undefined,
+                        "source": {
+                          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+                          "type": "Canvas",
+                        },
+                        "type": "SpecificResource",
+                      },
+                      "type": "Canvas",
+                      "untitled": false,
+                    },
+                    {
+                      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6",
+                      "isCanvasLeaf": true,
+                      "isRangeLeaf": false,
+                      "label": {
+                        "en": [
+                          "f. 3v",
+                        ],
+                      },
+                      "resource": {
+                        "selector": undefined,
+                        "source": {
+                          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6",
+                          "type": "Canvas",
+                        },
+                        "type": "SpecificResource",
+                      },
+                      "type": "Canvas",
+                      "untitled": false,
+                    },
+                  ],
+                  "label": {
+                    "en": [
+                      "Tuesday",
+                    ],
+                  },
+                  "type": "Range",
+                  "untitled": false,
+                },
+              ],
+              "label": {
+                "gez": [
+                  "Arede'et [አርድዕት]",
+                ],
+              },
+              "type": "Range",
+              "untitled": false,
+            },
+          ],
+          "label": {
+            "en": [
+              "Table of Contents",
+            ],
+          },
+          "type": "Range",
+          "untitled": false,
+        }
+      `);
+    });
+
+    test('it can make a table of contents tree', () => {
+      const vault = new Vault();
+      const manifest = vault.loadSync<ManifestNormalized>(tableOfContentManifests.id, tableOfContentsAvManifest);
+
+      invariant(manifest);
+
+      const tree = rangeToTableOfContentsTree(vault, manifest.structures[0] as any);
+
+      expect(renderRange(tree, true)).toMatchInlineSnapshot(`
+        "Gaetano Donizetti, L'Elisir D'Amore
+        ├── Atto Primo
+          ├── Preludio e Coro d'introduzione – Bel conforto al mietitore
+          └── Remainder of Atto Primo
+        └── Atto Secondo
+        "
+      `);
+
+      expect(tree).toMatchInlineSnapshot(`
+        {
+          "firstCanvas": {
+            "selector": {
+              "type": "FragmentSelector",
+              "value": "t=0,302.05",
+            },
+            "source": {
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+              "type": "Canvas",
+            },
+            "type": "SpecificResource",
+          },
+          "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/1",
+          "isCanvasLeaf": false,
+          "isRangeLeaf": false,
+          "items": [
+            {
+              "firstCanvas": {
+                "selector": {
+                  "type": "FragmentSelector",
+                  "value": "t=0,302.05",
+                },
+                "source": {
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                  "type": "Canvas",
+                },
+                "type": "SpecificResource",
+              },
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/2",
+              "isCanvasLeaf": false,
+              "isRangeLeaf": false,
+              "items": [
+                {
+                  "firstCanvas": {
+                    "selector": {
+                      "type": "FragmentSelector",
+                      "value": "t=0,302.05",
+                    },
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/3",
+                  "isCanvasLeaf": false,
+                  "isRangeLeaf": true,
+                  "items": [
+                    {
+                      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=0,302.05",
+                      "isCanvasLeaf": true,
+                      "isRangeLeaf": false,
+                      "label": {
+                        "none": [
+                          "Untitled",
+                        ],
+                      },
+                      "resource": {
+                        "selector": {
+                          "type": "FragmentSelector",
+                          "value": "t=0,302.05",
+                        },
+                        "source": {
+                          "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                          "type": "Canvas",
+                        },
+                        "type": "SpecificResource",
+                      },
+                      "type": "Canvas",
+                      "untitled": true,
+                    },
+                  ],
+                  "label": {
+                    "it": [
+                      "Preludio e Coro d'introduzione – Bel conforto al mietitore",
+                    ],
+                  },
+                  "type": "Range",
+                  "untitled": false,
+                },
+                {
+                  "firstCanvas": {
+                    "selector": {
+                      "type": "FragmentSelector",
+                      "value": "t=302.05,3971.24",
+                    },
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/4",
+                  "isCanvasLeaf": false,
+                  "isRangeLeaf": true,
+                  "items": [
+                    {
+                      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=302.05,3971.24",
+                      "isCanvasLeaf": true,
+                      "isRangeLeaf": false,
+                      "label": {
+                        "none": [
+                          "Untitled",
+                        ],
+                      },
+                      "resource": {
+                        "selector": {
+                          "type": "FragmentSelector",
+                          "value": "t=302.05,3971.24",
+                        },
+                        "source": {
+                          "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                          "type": "Canvas",
+                        },
+                        "type": "SpecificResource",
+                      },
+                      "type": "Canvas",
+                      "untitled": true,
+                    },
+                  ],
+                  "label": {
+                    "en": [
+                      "Remainder of Atto Primo",
+                    ],
+                  },
+                  "type": "Range",
+                  "untitled": false,
+                },
+              ],
+              "label": {
+                "it": [
+                  "Atto Primo",
+                ],
+              },
+              "type": "Range",
+              "untitled": false,
+            },
+            {
+              "firstCanvas": {
+                "selector": {
+                  "type": "FragmentSelector",
+                  "value": "t=3971.24",
+                },
+                "source": {
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                  "type": "Canvas",
+                },
+                "type": "SpecificResource",
+              },
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/5",
+              "isCanvasLeaf": false,
+              "isRangeLeaf": true,
+              "items": [
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=3971.24",
+                  "isCanvasLeaf": true,
+                  "isRangeLeaf": false,
+                  "label": {
+                    "none": [
+                      "Untitled",
+                    ],
+                  },
+                  "resource": {
+                    "selector": {
+                      "type": "FragmentSelector",
+                      "value": "t=3971.24",
+                    },
+                    "source": {
+                      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+                      "type": "Canvas",
+                    },
+                    "type": "SpecificResource",
+                  },
+                  "type": "Canvas",
+                  "untitled": true,
+                },
+              ],
+              "label": {
+                "it": [
+                  "Atto Secondo",
+                ],
+              },
+              "type": "Range",
+              "untitled": false,
+            },
+          ],
+          "label": {
+            "it": [
+              "Gaetano Donizetti, L'Elisir D'Amore",
+            ],
+          },
+          "type": "Range",
+          "untitled": false,
+        }
+      `);
+    });
+
+    test('it can make a table of contents tree', () => {
+      const vault = new Vault();
+      const manifest = vault.loadSync<ManifestNormalized>(wellcomeRange['@id'], wellcomeRange);
+
+      invariant(manifest);
+
+      const tree = rangesToTableOfContentsTree(vault, manifest.structures);
+
+      expect(renderRange(tree, true)).toMatchInlineSnapshot(`
+        "Table of Contents
+        ├── Cover
+        ├── 'Precatio terrae matris,' abbreviated and corrupted
+        ├── 'Precatio omnium herbarum,' abbreviated and corrupted
+        ├── Antonius Musa, 'De herba vettonica'
+        ├── Pseudo-Apuleius, 'Herbarius'
+        ├── Anonymous, 'De taxone'
+        ├── Sextus Placitus, 'De medicina ex animalibus,' (continues at f.76r)
+        ├── 'Curae herbarum,' interpolated within the Sextus Placitus herbal
+        ├── Receipts, interpolated within the Sextus Placitus herbal
+        ├── Illustration
+        ├── Sextus Placitus, 'De medicina ex animalibus,' (continued from f.46v)
+        ├── Relation of a cure of a friend of the scribe
+        ├── Tables of Roman and Arabic numerals from 1 to 1,000,000
+        └── Cover
+        "
+      `);
+    });
+
+    test('it can parse BL manifest', () => {
+      const vault = new Vault();
+      const manifest = vault.loadSync<ManifestNormalized>(blManifest.id, blManifest);
+
+      invariant(manifest);
+
+      const tree = rangesToTableOfContentsTree(vault, manifest.structures);
+
+      expect(renderRange(tree, true)).toMatchInlineSnapshot(`
+        "Wiltshire and Dorset, dub of disks / Fanny Rumble, A. Collins, Perrier (01:07:55)
+        ├── The turmut hoeing (02:29)
+        ├── She stole my heart away (02:08)
+        ├── Dumble dum dollicky (Richard of Taunton Dean) (03:01)
+        ├── Mrs Fanny Rumble talks about herself (01:44)
+        ├── What shall I wear to the wedding, John? (03:25)
+        ├── Country courtship (05:50)
+        ├── Herbert Prince (05:00)
+          ├── Introductory talk: 'The young sailor cut down in his prime' (01:25)
+          └── The young sailor cut down in his prime (02:49)
+        └── Fanny Rumble / Albert Collins / Fred Perrier (25:17)
+          ├── O what shall I wear to the wedding, John? (03:57)
+          ├── O what shall I wear to the wedding, John? (02:47)
+          ├── The vly on the turmut (03:10)
+          ├── The vly on the turmut (01:37)
+          ├── Twas on a Monday morning (02:04)
+          ├── Twas on a Monday morning (02:22)
+          ├── Dumble dum dollicky (04:23)
+          └── Talk about herself (01:53)
+        "
+      `);
+    });
+  });
+});

--- a/fixtures/cookbook/toc-av.json
+++ b/fixtures/cookbook/toc-av.json
@@ -1,0 +1,99 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "it": ["L'Elisir D'Amore"],
+    "en": ["The Elixir of Love"]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+      "type": "Canvas",
+      "width": 1920,
+      "height": 1080,
+      "duration": 7278.422,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1/annotation_page/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1/annotation_page/1/annotation/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
+              "body": {
+                "id": "https://fixtures.iiif.io/video/indiana/donizetti-elixir/vae0637_accessH264_low.mp4",
+                "type": "Video",
+                "format": "video/mp4",
+                "height": 1080,
+                "width": 1920,
+                "duration": 7278.422
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "type": "Range",
+      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/1",
+      "label": {
+        "it": ["Gaetano Donizetti, L'Elisir D'Amore"]
+      },
+      "items": [
+        {
+          "type": "Range",
+          "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/2",
+          "label": {
+            "it": ["Atto Primo"]
+          },
+          "items": [
+            {
+              "type": "Range",
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/3",
+              "label": {
+                "it": ["Preludio e Coro d'introduzione – Bel conforto al mietitore"]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=0,302.05"
+                }
+              ]
+            },
+            {
+              "type": "Range",
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/4",
+              "label": {
+                "en": ["Remainder of Atto Primo"]
+              },
+              "items": [
+                {
+                  "type": "Canvas",
+                  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=302.05,3971.24"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "Range",
+          "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/range/5",
+          "label": {
+            "it": ["Atto Secondo"]
+          },
+          "items": [
+            {
+              "type": "Canvas",
+              "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=3971.24"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/cookbook/toc.json
+++ b/fixtures/cookbook/toc.json
@@ -1,0 +1,303 @@
+{
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["Ethiopic Ms 10"]
+  },
+  "items": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+      "type": "Canvas",
+      "label": {
+        "en": ["f. 1r"]
+      },
+      "height": 2504,
+      "width": 1768,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p1/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0001-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-1-21198-zz001d8m41_774608_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2504,
+                "width": 1768,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-1-21198-zz001d8m41_774608_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
+      "type": "Canvas",
+      "label": {
+        "en": ["f. 1v"]
+      },
+      "height": 2512,
+      "width": 1792,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p2/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0002-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-2-21198-zz001d8m5j_774612_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2512,
+                "width": 1792,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-2-21198-zz001d8m5j_774612_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+      "type": "Canvas",
+      "label": {
+        "en": ["f. 2r"]
+      },
+      "height": 2456,
+      "width": 1792,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p3/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0003-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-3-21198-zz001d8tm5_775004_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2456,
+                "width": 1792,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-3-21198-zz001d8tm5_775004_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4",
+      "type": "Canvas",
+      "label": {
+        "en": ["f. 2v"]
+      },
+      "height": 2440,
+      "width": 1760,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p4/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0004-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-4-21198-zz001d8tnp_775007_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2440,
+                "width": 1760,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-4-21198-zz001d8tnp_775007_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+      "type": "Canvas",
+      "label": {
+        "en": ["f. 3r"]
+      },
+      "height": 2416,
+      "width": 1776,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p5/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0005-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-5-21198-zz001d8v6f_775077_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2416,
+                "width": 1776,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-5-21198-zz001d8v6f_775077_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6",
+      "type": "Canvas",
+      "label": {
+        "en": ["f. 3v"]
+      },
+      "height": 2416,
+      "width": 1776,
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/page/p6/1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/annotation/p0006-image",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": {
+                "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-6-21198-zz001d8v7z_775085_master/full/max/0/default.jpg",
+                "type": "Image",
+                "format": "image/jpeg",
+                "height": 2416,
+                "width": 1776,
+                "service": [
+                  {
+                    "id": "https://iiif.io/api/image/3.0/example/reference/d3bbf5397c6df6b894c5991195c912ab-6-21198-zz001d8v7z_775085_master",
+                    "type": "ImageService3",
+                    "profile": "level1"
+                  }
+                ]
+              },
+              "target": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r0",
+      "type": "Range",
+      "label": {
+        "en": ["Table of Contents"]
+      },
+      "items": [
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r1",
+          "type": "Range",
+          "label": {
+            "gez": ["Tabiba Tabiban [ጠቢበ ጠቢባን]"]
+          },
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
+              "type": "Canvas"
+            },
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2",
+          "type": "Range",
+          "label": {
+            "gez": ["Arede'et [አርድዕት]"]
+          },
+          "items": [
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2/1",
+              "type": "Range",
+              "label": {
+                "en": ["Monday"]
+              },
+              "items": [
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p3",
+                  "type": "Canvas"
+                },
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p4",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r2/2",
+              "type": "Range",
+              "label": {
+                "en": ["Tuesday"]
+              },
+              "items": [
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p5",
+                  "type": "Canvas"
+                },
+                {
+                  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p6",
+                  "type": "Canvas"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/presentation-2/wellcome-range.json
+++ b/fixtures/presentation-2/wellcome-range.json
@@ -1,0 +1,19932 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@id": "https://iiif.wellcomecollection.org/presentation/v2/b19646045",
+  "@type": "sc:Manifest",
+  "label": "Herbal",
+  "metadata": [
+    {
+      "label": "Description",
+      "value": "<p>Written in a rounded gothic hand, 36/37 lines to a page. Some headings in red, and some capitals and paragraph marks in alternate red-blue, blue-red.</p>\n<p><b>Contents</b></p>\n\n<p>1. f. 1r <i>Precatio terrae matris</i>, abbreviated and corrupted</p>\n\n<p>Incipit: 'Dea sancta tellus regenerationis per que [sic] de cuncta gerensa [sic] generasti...'\n\n</p><p>Explicit: '...hoc michi es quod te suplex rogo'.</p>\n\n<p>2. ff. 1r-3v <i>Precatio omnium herbarum</i>, abbreviated and corrupted</p>\n\n<p>Incipit: 'V[o]s potestates omnes herbas. Or[o] [e]xoro magestatemque [sic] uos quas parens tellus...'</p>\n\n<p>Explicit: '...attussicos. Cxxxvi.'</p>\n\n<p>3. ff. 3v-6r Antonius Musa, <i>De herba vettonica</i></p>\n\n<p>Incipit: 'Caesari augusto prestantissimo...'</p>\n\n<p>Explicit: '...mire dolorem lenire experti afirmant'.</p>\n\n<p>4. ff. 6v-37r Pseudo-Apuleius, <i>Herbarius</i></p>\n\n<p>Incipit: 'Paucas uires herbarum et curationes corporis...'</p>\n\n<p>Explicit: 'Herbarium apulei platonici quem [sic] accept a chironi. Macistro Achilis. Et Ascolapio. Explicit feliciter.'</p>\n\n<p>5. ff. 37v-38v Anonymous, <i>De taxone</i></p>\n\n<p>Incipit: 'Non modo studiosus set etiam capecem mutuo inter uos congnouissem marcelline...'</p>\n\n<p>Explicit: '...et modice subsiccet et initiat sibi in cor pur [sic] purgabitur'.</p>\n\n<p>6. ff. 38v-46v and 76r-149v Sextus Placitus, <i>De medicina ex animalibus</i></p>\n\n<p>Incipit (f. 39r) 'De cervo et ad omnes homines cornus ceruinus habetuim...'</p>\n\n<p>Explicit: 'Explicit liber de uirtutibus herbarum peccudum et quorundam alliorum animalium etc.'.</p>\n\n<p>7. ff. 46v-68v <i>'Curae herbarum</i>, interpolated within the Sextus Placitus herbal</p>\n\n<p>Incipit: 'Nomen herbe licanis stefanotice. Folia habet oblonga...'</p>\n\n<p>Explicit: 'Paralyticus enim eam tonsam herbam cum lac bubulum et storacem calamitem statim eum liberabit. Expliciunt cure herbarum feliciter.'</p>\n\n<p>8. ff. 68v-75r Receipts, interpolated within Sextus Placitus herbal</p>\n\n<p>Begins: 'Ad cauculum de perna uteri quod appelatur uertebra...'</p>\n\n<p>Ends: '...ad distilationem [sic] urine'.</p>\n\n<p>9. ff. 150r-151r Relation of a cure of a friend of the scribe</p>\n\n<p>Begins: 'Conquestus est michi G. abustusus religiosus qui erat amicus meus...'.</p>\n\n<p>10. ff. 151v-152v Tables of Roman and Arabic numerals from 1 to 1,000,000.</p>\n\n<p>Initials: On fol. 1 are two illuminated historiated initials. The first a D, showing a seated bearded figure in a purple robe and blue over-dress, holding a red book [Hippocrates? Asklepius?]: below this another similar initial U showing three plants in a bowl [?]. In the upper corners, one on each side, a Sun and a Moon. On fol. 75v is a full page illustration in colours of three standing male figures, one of which is a nude boy: they appear on a filed of flowers, with three trees in the background. Charles Singer has suggested that this is probably a Christian version of the Presentation to Apuleius of the 'Herbarius' by Aesculapius and Chiron.</p>\n\n<p>The MS. is illustrated by 159 coloured, and 44 uncoloured drawings of plants and animals. In a few cases there are blank spaces where the illustrations have been omitted.</p>\n\n<p><b>Bibliography</b></p>\n\n<p>Clark, Willene B. and McMunn, Meradith T. <i>Beasts and birds of the Middle Ages: the bestiary and its legacy</i> (Philadelphia: University of Pennsylvania Press, 1989), p. 573.</p>\n\n<p>Collins, Minta. <i>Medieval Herbals: The Illustrative Traditions</i> (Toronto: University of Toronto Press, 2000), pp. 156-162, <i>et passim</i></p><p>\n\n</p><p>Kristeller, Paul Oskar; Cranz, Ferdinand Edward and Brown, Virginia. <i>Mediaeval and Renaissance Latin Translations and Commentaries</i>, vols. 4-5 (Washington DC: Catholic University of America Press, 1980), p. 128</p>"
+    },
+    {
+      "label": "Reference",
+      "value": "MS.573"
+    },
+    {
+      "label": "Publication/creation",
+      "value": "Mid 13th Century"
+    },
+    {
+      "label": "Physical description",
+      "value": "1 volume 152 ll. folio. 34 1/2 x 24 cm. On vellum. 17th century vellum binding. Some corners repaired: ff. 1 and 150r somewhat rubbed."
+    },
+    {
+      "label": "Contributors",
+      "value": "Musa, Antonius"
+    },
+    {
+      "label": "Subjects",
+      "value": "Medicine, Traditional; Formulas, recipes, etc.; Carnivora; Plants, Medicinal; Charms; Botany; Lunaria; Mandragora; Materia Medica; Medicine, Magic, mystic, and spagiric"
+    },
+    {
+      "label": "Acquisition note",
+      "value": "Purchased at a Hoepli Sale at Milan 13 June 1930, Lot 143."
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Collection"
+    },
+    {
+      "label": "Full conditions of use",
+      "value": "<span>This work has been identified as being free of known restrictions under copyright law, including all related and neighbouring rights and is being made available under the <a target=\"_top\" href=\"http://creativecommons.org/publicdomain/mark/1.0/\">Creative Commons, Public Domain Mark</a>.<br/><br/>You can copy, modify, distribute and perform the work, even for commercial purposes, without asking permission.</span>"
+    }
+  ],
+  "description": "<p>Written in a rounded gothic hand, 36/37 lines to a page. Some headings in red, and some capitals and paragraph marks in alternate red-blue, blue-red.</p>\n<p><b>Contents</b></p>\n\n<p>1. f. 1r <i>Precatio terrae matris</i>, abbreviated and corrupted</p>\n\n<p>Incipit: 'Dea sancta tellus regenerationis per que [sic] de cuncta gerensa [sic] generasti...'\n\n</p><p>Explicit: '...hoc michi es quod te suplex rogo'.</p>\n\n<p>2. ff. 1r-3v <i>Precatio omnium herbarum</i>, abbreviated and corrupted</p>\n\n<p>Incipit: 'V[o]s potestates omnes herbas. Or[o] [e]xoro magestatemque [sic] uos quas parens tellus...'</p>\n\n<p>Explicit: '...attussicos. Cxxxvi.'</p>\n\n<p>3. ff. 3v-6r Antonius Musa, <i>De herba vettonica</i></p>\n\n<p>Incipit: 'Caesari augusto prestantissimo...'</p>\n\n<p>Explicit: '...mire dolorem lenire experti afirmant'.</p>\n\n<p>4. ff. 6v-37r Pseudo-Apuleius, <i>Herbarius</i></p>\n\n<p>Incipit: 'Paucas uires herbarum et curationes corporis...'</p>\n\n<p>Explicit: 'Herbarium apulei platonici quem [sic] accept a chironi. Macistro Achilis. Et Ascolapio. Explicit feliciter.'</p>\n\n<p>5. ff. 37v-38v Anonymous, <i>De taxone</i></p>\n\n<p>Incipit: 'Non modo studiosus set etiam capecem mutuo inter uos congnouissem marcelline...'</p>\n\n<p>Explicit: '...et modice subsiccet et initiat sibi in cor pur [sic] purgabitur'.</p>\n\n<p>6. ff. 38v-46v and 76r-149v Sextus Placitus, <i>De medicina ex animalibus</i></p>\n\n<p>Incipit (f. 39r) 'De cervo et ad omnes homines cornus ceruinus habetuim...'</p>\n\n<p>Explicit: 'Explicit liber de uirtutibus herbarum peccudum et quorundam alliorum animalium etc.'.</p>\n\n<p>7. ff. 46v-68v <i>'Curae herbarum</i>, interpolated within the Sextus Placitus herbal</p>\n\n<p>Incipit: 'Nomen herbe licanis stefanotice. Folia habet oblonga...'</p>\n\n<p>Explicit: 'Paralyticus enim eam tonsam herbam cum lac bubulum et storacem calamitem statim eum liberabit. Expliciunt cure herbarum feliciter.'</p>\n\n<p>8. ff. 68v-75r Receipts, interpolated within Sextus Placitus herbal</p>\n\n<p>Begins: 'Ad cauculum de perna uteri quod appelatur uertebra...'</p>\n\n<p>Ends: '...ad distilationem [sic] urine'.</p>\n\n<p>9. ff. 150r-151r Relation of a cure of a friend of the scribe</p>\n\n<p>Begins: 'Conquestus est michi G. abustusus religiosus qui erat amicus meus...'.</p>\n\n<p>10. ff. 151v-152v Tables of Roman and Arabic numerals from 1 to 1,000,000.</p>\n\n<p>Initials: On fol. 1 are two illuminated historiated initials. The first a D, showing a seated bearded figure in a purple robe and blue over-dress, holding a red book [Hippocrates? Asklepius?]: below this another similar initial U showing three plants in a bowl [?]. In the upper corners, one on each side, a Sun and a Moon. On fol. 75v is a full page illustration in colours of three standing male figures, one of which is a nude boy: they appear on a filed of flowers, with three trees in the background. Charles Singer has suggested that this is probably a Christian version of the Presentation to Apuleius of the 'Herbarius' by Aesculapius and Chiron.</p>\n\n<p>The MS. is illustrated by 159 coloured, and 44 uncoloured drawings of plants and animals. In a few cases there are blank spaces where the illustrations have been omitted.</p>\n\n<p><b>Bibliography</b></p>\n\n<p>Clark, Willene B. and McMunn, Meradith T. <i>Beasts and birds of the Middle Ages: the bestiary and its legacy</i> (Philadelphia: University of Pennsylvania Press, 1989), p. 573.</p>\n\n<p>Collins, Minta. <i>Medieval Herbals: The Illustrative Traditions</i> (Toronto: University of Toronto Press, 2000), pp. 156-162, <i>et passim</i></p><p>\n\n</p><p>Kristeller, Paul Oskar; Cranz, Ferdinand Edward and Brown, Virginia. <i>Mediaeval and Renaissance Latin Translations and Commentaries</i>, vols. 4-5 (Washington DC: Catholic University of America Press, 1980), p. 128</p>",
+  "thumbnail": {
+    "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0001.JP2/full/71,100/0/default.jpg",
+    "@type": "dctypes:Image",
+    "service": {
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0001.JP2",
+      "profile": "http://iiif.io/api/image/2/level0.json",
+      "protocol": "http://iiif.io/api/image",
+      "width": 724,
+      "height": 1024,
+      "sizes": [
+        {
+          "width": 71,
+          "height": 100
+        },
+        {
+          "width": 141,
+          "height": 200
+        },
+        {
+          "width": 283,
+          "height": 400
+        },
+        {
+          "width": 724,
+          "height": 1024
+        }
+      ]
+    }
+  },
+  "license": "http://creativecommons.org/publicdomain/mark/1.0/",
+  "logo": "https://iiif.wellcomecollection.org/logos/wellcome-collection-black.png",
+  "related": {
+    "@id": "https://wellcomecollection.org/works/x7pztwrp",
+    "format": "text/html",
+    "label": "Herbal"
+  },
+  "seeAlso": {
+    "@id": "https://api.wellcomecollection.org/catalogue/v2/works/x7pztwrp",
+    "profile": "https://api.wellcomecollection.org/catalogue/v2/context.json",
+    "format": "application/json",
+    "label": "Wellcome Collection Catalogue API"
+  },
+  "service": [
+    {
+      "@context": "http://universalviewer.io/context.json",
+      "@id": "http://wellcomelibrary.org/service/trackingLabels/b19646045",
+      "profile": "http://universalviewer.io/tracking-extensions-profile",
+      "trackingLabel": "Format: Archive, Institution: n/a, Identifier: b19646045, Digicode: digwms, Collection code: MS.573"
+    },
+    {
+      "@context": "http://wellcomelibrary.org/ld/iiif-ext/0/context.json",
+      "@id": "https://wellcomelibrary.org/iiif/b19646045/access-control-hints-service",
+      "profile": "http://wellcomelibrary.org/ld/iiif-ext/access-control-hints",
+      "accessHint": "open"
+    }
+  ],
+  "sequences": [
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/v2/b19646045/sequences/s0",
+      "@type": "sc:Sequence",
+      "label": "Sequence s0",
+      "rendering": {
+        "@id": "https://iiif.wellcomecollection.org/pdf/b19646045",
+        "label": "View as PDF",
+        "format": "application/pdf"
+      },
+      "canvases": [
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0001.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0001.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0001.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6923,
+          "width": 4892,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0001.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0001.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0001.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4892,
+                  "height": 6923
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0001.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0002.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0002.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0002.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 714,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 714,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6087,
+          "width": 4244,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0002.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0002.JP2/full/714,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 714,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0002.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4244,
+                  "height": 6087
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0002.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0003.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0003.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0003.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 704,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 275,
+                  "height": 400
+                },
+                {
+                  "width": 704,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6337,
+          "width": 4356,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0003.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0003.JP2/full/704,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 704,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0003.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4356,
+                  "height": 6337
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0003.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0004.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0004.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0004.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 723,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 723,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6084,
+          "width": 4295,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0004.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0004.JP2/full/723,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 723,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0004.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4295,
+                  "height": 6084
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0004.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0005.JP2",
+          "@type": "sc:Canvas",
+          "label": "1r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0005.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0005.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 693,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 135,
+                  "height": 200
+                },
+                {
+                  "width": 271,
+                  "height": 400
+                },
+                {
+                  "width": 693,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6303,
+          "width": 4263,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0005.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0005.JP2/full/693,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 693,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0005.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4263,
+                  "height": 6303
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0005.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0006.JP2",
+          "@type": "sc:Canvas",
+          "label": "1v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0006.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0006.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 719,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 281,
+                  "height": 400
+                },
+                {
+                  "width": 719,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6116,
+          "width": 4293,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0006.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0006.JP2/full/719,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 719,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0006.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4293,
+                  "height": 6116
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0006.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0007.JP2",
+          "@type": "sc:Canvas",
+          "label": "2r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0007.JP2/full/67,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0007.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 683,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 67,
+                  "height": 100
+                },
+                {
+                  "width": 133,
+                  "height": 200
+                },
+                {
+                  "width": 267,
+                  "height": 400
+                },
+                {
+                  "width": 683,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6318,
+          "width": 4216,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0007.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0007.JP2/full/683,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 683,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0007.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4216,
+                  "height": 6318
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0007.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0008.JP2",
+          "@type": "sc:Canvas",
+          "label": "2v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0008.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0008.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 723,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 723,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6107,
+          "width": 4311,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0008.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0008.JP2/full/723,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 723,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0008.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4311,
+                  "height": 6107
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0008.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0009.JP2",
+          "@type": "sc:Canvas",
+          "label": "3r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0009.JP2/full/66,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0009.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 676,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 66,
+                  "height": 100
+                },
+                {
+                  "width": 132,
+                  "height": 200
+                },
+                {
+                  "width": 264,
+                  "height": 400
+                },
+                {
+                  "width": 676,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6364,
+          "width": 4199,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0009.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0009.JP2/full/676,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 676,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0009.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4199,
+                  "height": 6364
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0009.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0010.JP2",
+          "@type": "sc:Canvas",
+          "label": "3v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0010.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0010.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 718,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 718,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6107,
+          "width": 4281,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0010.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0010.JP2/full/718,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 718,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0010.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4281,
+                  "height": 6107
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0010.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0011.JP2",
+          "@type": "sc:Canvas",
+          "label": "4r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0011.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0011.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 702,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 274,
+                  "height": 400
+                },
+                {
+                  "width": 702,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6273,
+          "width": 4298,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0011.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0011.JP2/full/702,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 702,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0011.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4298,
+                  "height": 6273
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0011.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0012.JP2",
+          "@type": "sc:Canvas",
+          "label": "4v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0012.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0012.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 722,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 722,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6088,
+          "width": 4293,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0012.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0012.JP2/full/722,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 722,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0012.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4293,
+                  "height": 6088
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0012.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0013.JP2",
+          "@type": "sc:Canvas",
+          "label": "5r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0013.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0013.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 712,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 712,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6199,
+          "width": 4313,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0013.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0013.JP2/full/712,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 712,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0013.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4313,
+                  "height": 6199
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0013.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0014.JP2",
+          "@type": "sc:Canvas",
+          "label": "5v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0014.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0014.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 718,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 718,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6115,
+          "width": 4286,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0014.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0014.JP2/full/718,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 718,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0014.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4286,
+                  "height": 6115
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0014.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0015.JP2",
+          "@type": "sc:Canvas",
+          "label": "6r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0015.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0015.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 699,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 273,
+                  "height": 400
+                },
+                {
+                  "width": 699,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6241,
+          "width": 4261,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0015.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0015.JP2/full/699,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 699,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0015.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4261,
+                  "height": 6241
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0015.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0016.JP2",
+          "@type": "sc:Canvas",
+          "label": "6v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0016.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0016.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 727,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 727,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6088,
+          "width": 4322,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0016.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0016.JP2/full/727,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 727,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0016.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4322,
+                  "height": 6088
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0016.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0017.JP2",
+          "@type": "sc:Canvas",
+          "label": "7r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0017.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0017.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 699,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 273,
+                  "height": 400
+                },
+                {
+                  "width": 699,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6276,
+          "width": 4282,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0017.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0017.JP2/full/699,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 699,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0017.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4282,
+                  "height": 6276
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0017.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0018.JP2",
+          "@type": "sc:Canvas",
+          "label": "7v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0018.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0018.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 723,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 723,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6084,
+          "width": 4295,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0018.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0018.JP2/full/723,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 723,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0018.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4295,
+                  "height": 6084
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0018.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0019.JP2",
+          "@type": "sc:Canvas",
+          "label": "8r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0019.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0019.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 699,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 273,
+                  "height": 400
+                },
+                {
+                  "width": 699,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6218,
+          "width": 4246,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0019.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0019.JP2/full/699,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 699,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0019.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4246,
+                  "height": 6218
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0019.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0020.JP2",
+          "@type": "sc:Canvas",
+          "label": "8v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0020.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0020.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6080,
+          "width": 4330,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0020.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0020.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0020.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4330,
+                  "height": 6080
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0020.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0021.JP2",
+          "@type": "sc:Canvas",
+          "label": "9r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0021.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0021.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 698,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 698,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6235,
+          "width": 4247,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0021.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0021.JP2/full/698,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 698,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0021.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4247,
+                  "height": 6235
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0021.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0022.JP2",
+          "@type": "sc:Canvas",
+          "label": "9v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0022.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0022.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6112,
+          "width": 4354,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0022.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0022.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0022.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4354,
+                  "height": 6112
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0022.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0023.JP2",
+          "@type": "sc:Canvas",
+          "label": "10r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0023.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0023.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 698,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 273,
+                  "height": 400
+                },
+                {
+                  "width": 698,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6247,
+          "width": 4259,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0023.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0023.JP2/full/698,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 698,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0023.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4259,
+                  "height": 6247
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0023.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0024.JP2",
+          "@type": "sc:Canvas",
+          "label": "10v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0024.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0024.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 728,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 728,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4346,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0024.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0024.JP2/full/728,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 728,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0024.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4346,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0024.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0025.JP2",
+          "@type": "sc:Canvas",
+          "label": "11r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0025.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0025.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 696,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 696,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6235,
+          "width": 4235,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0025.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0025.JP2/full/696,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 696,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0025.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4235,
+                  "height": 6235
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0025.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0026.JP2",
+          "@type": "sc:Canvas",
+          "label": "11v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0026.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0026.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6076,
+          "width": 4353,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0026.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0026.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0026.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4353,
+                  "height": 6076
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0026.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0027.JP2",
+          "@type": "sc:Canvas",
+          "label": "12r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0027.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0027.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 696,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 696,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6251,
+          "width": 4246,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0027.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0027.JP2/full/696,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 696,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0027.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4246,
+                  "height": 6251
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0027.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0028.JP2",
+          "@type": "sc:Canvas",
+          "label": "12v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0028.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0028.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 726,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 726,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6094,
+          "width": 4319,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0028.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0028.JP2/full/726,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 726,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0028.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4319,
+                  "height": 6094
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0028.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0029.JP2",
+          "@type": "sc:Canvas",
+          "label": "13r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0029.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0029.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 693,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 135,
+                  "height": 200
+                },
+                {
+                  "width": 271,
+                  "height": 400
+                },
+                {
+                  "width": 693,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6238,
+          "width": 4224,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0029.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0029.JP2/full/693,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 693,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0029.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4224,
+                  "height": 6238
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0029.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0030.JP2",
+          "@type": "sc:Canvas",
+          "label": "13v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0030.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0030.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 726,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 726,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6094,
+          "width": 4319,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0030.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0030.JP2/full/726,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 726,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0030.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4319,
+                  "height": 6094
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0030.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0031.JP2",
+          "@type": "sc:Canvas",
+          "label": "14r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0031.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0031.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 694,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 271,
+                  "height": 400
+                },
+                {
+                  "width": 694,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6227,
+          "width": 4223,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0031.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0031.JP2/full/694,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 694,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0031.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4223,
+                  "height": 6227
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0031.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0032.JP2",
+          "@type": "sc:Canvas",
+          "label": "14v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0032.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0032.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 726,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 726,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6094,
+          "width": 4320,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0032.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0032.JP2/full/726,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 726,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0032.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4320,
+                  "height": 6094
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0032.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0033.JP2",
+          "@type": "sc:Canvas",
+          "label": "15r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0033.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0033.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 696,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 696,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6233,
+          "width": 4236,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0033.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0033.JP2/full/696,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 696,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0033.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4236,
+                  "height": 6233
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0033.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0034.JP2",
+          "@type": "sc:Canvas",
+          "label": "15v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0034.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0034.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 718,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 718,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6167,
+          "width": 4324,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0034.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0034.JP2/full/718,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 718,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0034.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4324,
+                  "height": 6167
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0034.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0035.JP2",
+          "@type": "sc:Canvas",
+          "label": "16r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0035.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0035.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 696,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 696,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6249,
+          "width": 4247,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0035.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0035.JP2/full/696,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 696,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0035.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4247,
+                  "height": 6249
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0035.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0036.JP2",
+          "@type": "sc:Canvas",
+          "label": "16v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0036.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0036.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6095,
+          "width": 4370,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0036.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0036.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0036.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4370,
+                  "height": 6095
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0036.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0037.JP2",
+          "@type": "sc:Canvas",
+          "label": "17r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0037.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0037.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 700,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 274,
+                  "height": 400
+                },
+                {
+                  "width": 700,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6230,
+          "width": 4261,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0037.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0037.JP2/full/700,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 700,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0037.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4261,
+                  "height": 6230
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0037.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0038.JP2",
+          "@type": "sc:Canvas",
+          "label": "17v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0038.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0038.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6144,
+          "width": 4372,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0038.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0038.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0038.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4372,
+                  "height": 6144
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0038.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0039.JP2",
+          "@type": "sc:Canvas",
+          "label": "18r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0039.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0039.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 702,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 274,
+                  "height": 400
+                },
+                {
+                  "width": 702,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6220,
+          "width": 4262,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0039.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0039.JP2/full/702,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 702,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0039.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4262,
+                  "height": 6220
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0039.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0040.JP2",
+          "@type": "sc:Canvas",
+          "label": "18v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0040.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0040.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 737,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 737,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6102,
+          "width": 4394,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0040.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0040.JP2/full/737,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 737,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0040.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4394,
+                  "height": 6102
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0040.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0041.JP2",
+          "@type": "sc:Canvas",
+          "label": "19r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0041.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0041.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 696,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 696,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6229,
+          "width": 4233,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0041.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0041.JP2/full/696,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 696,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0041.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4233,
+                  "height": 6229
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0041.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0042.JP2",
+          "@type": "sc:Canvas",
+          "label": "19v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0042.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0042.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 735,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 735,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6094,
+          "width": 4375,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0042.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0042.JP2/full/735,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0042.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4375,
+                  "height": 6094
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0042.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0043.JP2",
+          "@type": "sc:Canvas",
+          "label": "20r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0043.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0043.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 696,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 696,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6220,
+          "width": 4227,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0043.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0043.JP2/full/696,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 696,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0043.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4227,
+                  "height": 6220
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0043.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0044.JP2",
+          "@type": "sc:Canvas",
+          "label": "20v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0044.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0044.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 736,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 736,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6094,
+          "width": 4380,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0044.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0044.JP2/full/736,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 736,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0044.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4380,
+                  "height": 6094
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0044.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0045.JP2",
+          "@type": "sc:Canvas",
+          "label": "21r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0045.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0045.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 693,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 135,
+                  "height": 200
+                },
+                {
+                  "width": 271,
+                  "height": 400
+                },
+                {
+                  "width": 693,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6232,
+          "width": 4220,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0045.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0045.JP2/full/693,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 693,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0045.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4220,
+                  "height": 6232
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0045.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0046.JP2",
+          "@type": "sc:Canvas",
+          "label": "21v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0046.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0046.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 736,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 736,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6093,
+          "width": 4380,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0046.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0046.JP2/full/736,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 736,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0046.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4380,
+                  "height": 6093
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0046.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0047.JP2",
+          "@type": "sc:Canvas",
+          "label": "22r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0047.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0047.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 703,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 275,
+                  "height": 400
+                },
+                {
+                  "width": 703,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6201,
+          "width": 4258,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0047.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0047.JP2/full/703,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 703,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0047.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4258,
+                  "height": 6201
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0047.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0048.JP2",
+          "@type": "sc:Canvas",
+          "label": "22v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0048.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0048.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 738,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 738,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6082,
+          "width": 4382,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0048.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0048.JP2/full/738,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 738,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0048.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4382,
+                  "height": 6082
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0048.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0049.JP2",
+          "@type": "sc:Canvas",
+          "label": "23r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0049.JP2/full/68,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0049.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 697,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 68,
+                  "height": 100
+                },
+                {
+                  "width": 136,
+                  "height": 200
+                },
+                {
+                  "width": 272,
+                  "height": 400
+                },
+                {
+                  "width": 697,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6253,
+          "width": 4259,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0049.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0049.JP2/full/697,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 697,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0049.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4259,
+                  "height": 6253
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0049.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0050.JP2",
+          "@type": "sc:Canvas",
+          "label": "23v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0050.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0050.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 738,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 738,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6081,
+          "width": 4383,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0050.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0050.JP2/full/738,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 738,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0050.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4383,
+                  "height": 6081
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0050.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0051.JP2",
+          "@type": "sc:Canvas",
+          "label": "24r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0051.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0051.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 716,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6242,
+          "width": 4362,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0051.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0051.JP2/full/716,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0051.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4362,
+                  "height": 6242
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0051.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0052.JP2",
+          "@type": "sc:Canvas",
+          "label": "24v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0052.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0052.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 741,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 741,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6091,
+          "width": 4410,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0052.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0052.JP2/full/741,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 741,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0052.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4410,
+                  "height": 6091
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0052.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0053.JP2",
+          "@type": "sc:Canvas",
+          "label": "25r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0053.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0053.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 711,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 711,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6242,
+          "width": 4333,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0053.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0053.JP2/full/711,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 711,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0053.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4333,
+                  "height": 6242
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0053.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0054.JP2",
+          "@type": "sc:Canvas",
+          "label": "25v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0054.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0054.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 739,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 739,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6095,
+          "width": 4401,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0054.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0054.JP2/full/739,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0054.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4401,
+                  "height": 6095
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0054.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0055.JP2",
+          "@type": "sc:Canvas",
+          "label": "26r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0055.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0055.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 713,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 713,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6242,
+          "width": 4347,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0055.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0055.JP2/full/713,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 713,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0055.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4347,
+                  "height": 6242
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0055.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0056.JP2",
+          "@type": "sc:Canvas",
+          "label": "26v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0056.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0056.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 746,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 746,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6088,
+          "width": 4438,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0056.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0056.JP2/full/746,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 746,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0056.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4438,
+                  "height": 6088
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0056.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0057.JP2",
+          "@type": "sc:Canvas",
+          "label": "27r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0057.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0057.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 710,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 710,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6242,
+          "width": 4330,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0057.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0057.JP2/full/710,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 710,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0057.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4330,
+                  "height": 6242
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0057.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0058.JP2",
+          "@type": "sc:Canvas",
+          "label": "27v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0058.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0058.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 748,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 748,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6088,
+          "width": 4448,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0058.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0058.JP2/full/748,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 748,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0058.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4448,
+                  "height": 6088
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0058.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0059.JP2",
+          "@type": "sc:Canvas",
+          "label": "28r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0059.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0059.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 708,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 708,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6260,
+          "width": 4331,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0059.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0059.JP2/full/708,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 708,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0059.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4331,
+                  "height": 6260
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0059.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0060.JP2",
+          "@type": "sc:Canvas",
+          "label": "28v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0060.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0060.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6099,
+          "width": 4452,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0060.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0060.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0060.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4452,
+                  "height": 6099
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0060.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0061.JP2",
+          "@type": "sc:Canvas",
+          "label": "29r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0061.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0061.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 704,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 275,
+                  "height": 400
+                },
+                {
+                  "width": 704,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6204,
+          "width": 4264,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0061.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0061.JP2/full/704,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 704,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0061.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4264,
+                  "height": 6204
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0061.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0062.JP2",
+          "@type": "sc:Canvas",
+          "label": "29v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0062.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0062.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6103,
+          "width": 4451,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0062.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0062.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0062.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4451,
+                  "height": 6103
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0062.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0063.JP2",
+          "@type": "sc:Canvas",
+          "label": "30r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0063.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0063.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 719,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 281,
+                  "height": 400
+                },
+                {
+                  "width": 719,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6242,
+          "width": 4383,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0063.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0063.JP2/full/719,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 719,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0063.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4383,
+                  "height": 6242
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0063.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0064.JP2",
+          "@type": "sc:Canvas",
+          "label": "30v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0064.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0064.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 746,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 746,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6107,
+          "width": 4451,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0064.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0064.JP2/full/746,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 746,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0064.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4451,
+                  "height": 6107
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0064.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0065.JP2",
+          "@type": "sc:Canvas",
+          "label": "31r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0065.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0065.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6260,
+          "width": 4432,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0065.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0065.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0065.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4432,
+                  "height": 6260
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0065.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0066.JP2",
+          "@type": "sc:Canvas",
+          "label": "31v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0066.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0066.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 746,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 746,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6109,
+          "width": 4450,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0066.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0066.JP2/full/746,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 746,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0066.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4450,
+                  "height": 6109
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0066.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0067.JP2",
+          "@type": "sc:Canvas",
+          "label": "32r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0067.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0067.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6242,
+          "width": 4416,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0067.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0067.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0067.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4416,
+                  "height": 6242
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0067.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0068.JP2",
+          "@type": "sc:Canvas",
+          "label": "32v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0068.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0068.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 745,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 745,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6093,
+          "width": 4435,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0068.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0068.JP2/full/745,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 745,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0068.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4435,
+                  "height": 6093
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0068.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0069.JP2",
+          "@type": "sc:Canvas",
+          "label": "33r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0069.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0069.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6261,
+          "width": 4429,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0069.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0069.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0069.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4429,
+                  "height": 6261
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0069.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0070.JP2",
+          "@type": "sc:Canvas",
+          "label": "33v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0070.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0070.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 748,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 748,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6098,
+          "width": 4453,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0070.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0070.JP2/full/748,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 748,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0070.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4453,
+                  "height": 6098
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0070.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0071.JP2",
+          "@type": "sc:Canvas",
+          "label": "34r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0071.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0071.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 716,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6212,
+          "width": 4342,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0071.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0071.JP2/full/716,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0071.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4342,
+                  "height": 6212
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0071.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0072.JP2",
+          "@type": "sc:Canvas",
+          "label": "34v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0072.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0072.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6101,
+          "width": 4453,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0072.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0072.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0072.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4453,
+                  "height": 6101
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0072.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0073.JP2",
+          "@type": "sc:Canvas",
+          "label": "35r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0073.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0073.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 722,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 722,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6223,
+          "width": 4390,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0073.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0073.JP2/full/722,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 722,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0073.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4390,
+                  "height": 6223
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0073.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0074.JP2",
+          "@type": "sc:Canvas",
+          "label": "35v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0074.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0074.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 748,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 748,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6097,
+          "width": 4453,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0074.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0074.JP2/full/748,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 748,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0074.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4453,
+                  "height": 6097
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0074.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0075.JP2",
+          "@type": "sc:Canvas",
+          "label": "36r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0075.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0075.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 721,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 721,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6240,
+          "width": 4395,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0075.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0075.JP2/full/721,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 721,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0075.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4395,
+                  "height": 6240
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0075.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0076.JP2",
+          "@type": "sc:Canvas",
+          "label": "36v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0076.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0076.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 751,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 293,
+                  "height": 400
+                },
+                {
+                  "width": 751,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6099,
+          "width": 4473,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0076.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0076.JP2/full/751,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 751,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0076.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4473,
+                  "height": 6099
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0076.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0077.JP2",
+          "@type": "sc:Canvas",
+          "label": "37r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0077.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0077.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 721,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 721,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6236,
+          "width": 4391,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0077.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0077.JP2/full/721,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 721,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0077.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4391,
+                  "height": 6236
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0077.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0078.JP2",
+          "@type": "sc:Canvas",
+          "label": "37v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0078.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0078.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 753,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 753,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6092,
+          "width": 4479,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0078.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0078.JP2/full/753,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 753,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0078.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4479,
+                  "height": 6092
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0078.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0079.JP2",
+          "@type": "sc:Canvas",
+          "label": "38r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0079.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0079.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 722,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 722,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6235,
+          "width": 4394,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0079.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0079.JP2/full/722,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 722,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0079.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4394,
+                  "height": 6235
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0079.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0080.JP2",
+          "@type": "sc:Canvas",
+          "label": "38v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0080.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0080.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 753,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 753,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6091,
+          "width": 4479,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0080.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0080.JP2/full/753,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 753,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0080.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4479,
+                  "height": 6091
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0080.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0081.JP2",
+          "@type": "sc:Canvas",
+          "label": "39r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0081.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0081.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 730,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 730,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6236,
+          "width": 4448,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0081.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0081.JP2/full/730,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0081.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4448,
+                  "height": 6236
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0081.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0082.JP2",
+          "@type": "sc:Canvas",
+          "label": "39v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0082.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0082.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 748,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 748,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4476,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0082.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0082.JP2/full/748,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 748,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0082.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4476,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0082.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0083.JP2",
+          "@type": "sc:Canvas",
+          "label": "40r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0083.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0083.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 735,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 735,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6221,
+          "width": 4463,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0083.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0083.JP2/full/735,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0083.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4463,
+                  "height": 6221
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0083.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0084.JP2",
+          "@type": "sc:Canvas",
+          "label": "40v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0084.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0084.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 756,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 756,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6086,
+          "width": 4494,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0084.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0084.JP2/full/756,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 756,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0084.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4494,
+                  "height": 6086
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0084.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0085.JP2",
+          "@type": "sc:Canvas",
+          "label": "41r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0085.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0085.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 730,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 730,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6224,
+          "width": 4439,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0085.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0085.JP2/full/730,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0085.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4439,
+                  "height": 6224
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0085.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0086.JP2",
+          "@type": "sc:Canvas",
+          "label": "41v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0086.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0086.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 753,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 753,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6095,
+          "width": 4479,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0086.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0086.JP2/full/753,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 753,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0086.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4479,
+                  "height": 6095
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0086.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0087.JP2",
+          "@type": "sc:Canvas",
+          "label": "42r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0087.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0087.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 736,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 736,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6195,
+          "width": 4454,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0087.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0087.JP2/full/736,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 736,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0087.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4454,
+                  "height": 6195
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0087.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0088.JP2",
+          "@type": "sc:Canvas",
+          "label": "42v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0088.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0088.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 752,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 752,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6095,
+          "width": 4477,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0088.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0088.JP2/full/752,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 752,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0088.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4477,
+                  "height": 6095
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0088.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0089.JP2",
+          "@type": "sc:Canvas",
+          "label": "43r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0089.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0089.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 731,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 731,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6211,
+          "width": 4432,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0089.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0089.JP2/full/731,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 731,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0089.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4432,
+                  "height": 6211
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0089.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0090.JP2",
+          "@type": "sc:Canvas",
+          "label": "43v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0090.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0090.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 757,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 757,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6091,
+          "width": 4505,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0090.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0090.JP2/full/757,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 757,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0090.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4505,
+                  "height": 6091
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0090.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0091.JP2",
+          "@type": "sc:Canvas",
+          "label": "44r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0091.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0091.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 732,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 286,
+                  "height": 400
+                },
+                {
+                  "width": 732,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6207,
+          "width": 4439,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0091.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0091.JP2/full/732,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 732,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0091.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4439,
+                  "height": 6207
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0091.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0092.JP2",
+          "@type": "sc:Canvas",
+          "label": "44v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0092.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0092.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 752,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 752,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6123,
+          "width": 4496,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0092.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0092.JP2/full/752,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 752,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0092.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4496,
+                  "height": 6123
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0092.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0093.JP2",
+          "@type": "sc:Canvas",
+          "label": "45r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0093.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0093.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 732,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 286,
+                  "height": 400
+                },
+                {
+                  "width": 732,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6207,
+          "width": 4438,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0093.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0093.JP2/full/732,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 732,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0093.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4438,
+                  "height": 6207
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0093.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0094.JP2",
+          "@type": "sc:Canvas",
+          "label": "45v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0094.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0094.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 757,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 757,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6078,
+          "width": 4494,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0094.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0094.JP2/full/757,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 757,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0094.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4494,
+                  "height": 6078
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0094.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0095.JP2",
+          "@type": "sc:Canvas",
+          "label": "46r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0095.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0095.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 726,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 726,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6237,
+          "width": 4421,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0095.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0095.JP2/full/726,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 726,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0095.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4421,
+                  "height": 6237
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0095.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0096.JP2",
+          "@type": "sc:Canvas",
+          "label": "46v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0096.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0096.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 754,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 754,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6117,
+          "width": 4502,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0096.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0096.JP2/full/754,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 754,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0096.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4502,
+                  "height": 6117
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0096.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0097.JP2",
+          "@type": "sc:Canvas",
+          "label": "47r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0097.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0097.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6195,
+          "width": 4440,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0097.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0097.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0097.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4440,
+                  "height": 6195
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0097.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0098.JP2",
+          "@type": "sc:Canvas",
+          "label": "47v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0098.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0098.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6112,
+          "width": 4504,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0098.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0098.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0098.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4504,
+                  "height": 6112
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0098.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0099.JP2",
+          "@type": "sc:Canvas",
+          "label": "48r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0099.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0099.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6198,
+          "width": 4440,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0099.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0099.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0099.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4440,
+                  "height": 6198
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0099.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0100.JP2",
+          "@type": "sc:Canvas",
+          "label": "48v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0100.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0100.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 752,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 752,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6105,
+          "width": 4483,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0100.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0100.JP2/full/752,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 752,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0100.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4483,
+                  "height": 6105
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0100.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0101.JP2",
+          "@type": "sc:Canvas",
+          "label": "49r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0101.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0101.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6194,
+          "width": 4441,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0101.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0101.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0101.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4441,
+                  "height": 6194
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0101.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0102.JP2",
+          "@type": "sc:Canvas",
+          "label": "49v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0102.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0102.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4512,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0102.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0102.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0102.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4512,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0102.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0103.JP2",
+          "@type": "sc:Canvas",
+          "label": "50r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0103.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0103.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 735,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 735,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6183,
+          "width": 4441,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0103.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0103.JP2/full/735,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0103.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4441,
+                  "height": 6183
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0103.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0104.JP2",
+          "@type": "sc:Canvas",
+          "label": "50v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0104.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0104.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 753,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 753,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6145,
+          "width": 4521,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0104.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0104.JP2/full/753,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 753,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0104.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4521,
+                  "height": 6145
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0104.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0105.JP2",
+          "@type": "sc:Canvas",
+          "label": "51r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0105.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0105.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 736,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 736,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6173,
+          "width": 4438,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0105.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0105.JP2/full/736,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 736,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0105.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4438,
+                  "height": 6173
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0105.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0106.JP2",
+          "@type": "sc:Canvas",
+          "label": "51v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0106.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0106.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6207,
+          "width": 4527,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0106.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0106.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0106.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4527,
+                  "height": 6207
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0106.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0107.JP2",
+          "@type": "sc:Canvas",
+          "label": "52r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0107.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0107.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6118,
+          "width": 4422,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0107.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0107.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0107.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4422,
+                  "height": 6118
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0107.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0108.JP2",
+          "@type": "sc:Canvas",
+          "label": "52v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0108.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0108.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6127,
+          "width": 4515,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0108.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0108.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0108.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4515,
+                  "height": 6127
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0108.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0109.JP2",
+          "@type": "sc:Canvas",
+          "label": "53r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0109.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0109.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 741,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 741,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6147,
+          "width": 4451,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0109.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0109.JP2/full/741,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 741,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0109.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4451,
+                  "height": 6147
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0109.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0110.JP2",
+          "@type": "sc:Canvas",
+          "label": "53v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0110.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0110.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6118,
+          "width": 4513,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0110.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0110.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0110.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4513,
+                  "height": 6118
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0110.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0111.JP2",
+          "@type": "sc:Canvas",
+          "label": "54r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0111.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0111.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 742,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 742,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6188,
+          "width": 4486,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0111.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0111.JP2/full/742,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 742,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0111.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4486,
+                  "height": 6188
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0111.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0112.JP2",
+          "@type": "sc:Canvas",
+          "label": "54v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0112.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0112.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6130,
+          "width": 4518,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0112.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0112.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0112.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4518,
+                  "height": 6130
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0112.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0113.JP2",
+          "@type": "sc:Canvas",
+          "label": "55r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0113.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0113.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6204,
+          "width": 4449,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0113.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0113.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0113.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4449,
+                  "height": 6204
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0113.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0114.JP2",
+          "@type": "sc:Canvas",
+          "label": "55v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0114.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0114.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6136,
+          "width": 4525,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0114.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0114.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0114.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4525,
+                  "height": 6136
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0114.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0115.JP2",
+          "@type": "sc:Canvas",
+          "label": "56r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0115.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0115.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 737,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 737,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6196,
+          "width": 4459,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0115.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0115.JP2/full/737,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 737,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0115.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4459,
+                  "height": 6196
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0115.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0116.JP2",
+          "@type": "sc:Canvas",
+          "label": "56v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0116.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0116.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 763,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6113,
+          "width": 4555,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0116.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0116.JP2/full/763,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0116.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4555,
+                  "height": 6113
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0116.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0117.JP2",
+          "@type": "sc:Canvas",
+          "label": "57r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0117.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0117.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6193,
+          "width": 4477,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0117.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0117.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0117.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4477,
+                  "height": 6193
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0117.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0118.JP2",
+          "@type": "sc:Canvas",
+          "label": "57v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0118.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0118.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 762,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 762,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6151,
+          "width": 4577,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0118.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0118.JP2/full/762,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 762,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0118.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4577,
+                  "height": 6151
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0118.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0119.JP2",
+          "@type": "sc:Canvas",
+          "label": "58r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0119.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0119.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 730,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 730,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4380,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0119.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0119.JP2/full/730,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0119.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4380,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0119.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0120.JP2",
+          "@type": "sc:Canvas",
+          "label": "58v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0120.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0120.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6107,
+          "width": 4577,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0120.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0120.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0120.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4577,
+                  "height": 6107
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0120.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0121.JP2",
+          "@type": "sc:Canvas",
+          "label": "59r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0121.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0121.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 728,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 728,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6154,
+          "width": 4376,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0121.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0121.JP2/full/728,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 728,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0121.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4376,
+                  "height": 6154
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0121.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0122.JP2",
+          "@type": "sc:Canvas",
+          "label": "59v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0122.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0122.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 762,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 762,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6156,
+          "width": 4578,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0122.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0122.JP2/full/762,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 762,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0122.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4578,
+                  "height": 6156
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0122.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0123.JP2",
+          "@type": "sc:Canvas",
+          "label": "60r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0123.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0123.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6153,
+          "width": 4382,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0123.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0123.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0123.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4382,
+                  "height": 6153
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0123.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0124.JP2",
+          "@type": "sc:Canvas",
+          "label": "60v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0124.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0124.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6117,
+          "width": 4578,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0124.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0124.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0124.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4578,
+                  "height": 6117
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0124.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0125.JP2",
+          "@type": "sc:Canvas",
+          "label": "61r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0125.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0125.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 732,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 286,
+                  "height": 400
+                },
+                {
+                  "width": 732,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6143,
+          "width": 4389,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0125.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0125.JP2/full/732,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 732,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0125.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4389,
+                  "height": 6143
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0125.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0126.JP2",
+          "@type": "sc:Canvas",
+          "label": "61v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0126.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0126.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6102,
+          "width": 4568,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0126.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0126.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0126.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4568,
+                  "height": 6102
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0126.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0127.JP2",
+          "@type": "sc:Canvas",
+          "label": "62r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0127.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0127.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 734,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 734,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6185,
+          "width": 4433,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0127.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0127.JP2/full/734,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 734,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0127.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4433,
+                  "height": 6185
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0127.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0128.JP2",
+          "@type": "sc:Canvas",
+          "label": "62v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0128.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0128.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6102,
+          "width": 4598,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0128.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0128.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0128.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4598,
+                  "height": 6102
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0128.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0129.JP2",
+          "@type": "sc:Canvas",
+          "label": "63r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0129.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0129.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6185,
+          "width": 4470,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0129.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0129.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0129.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4470,
+                  "height": 6185
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0129.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0130.JP2",
+          "@type": "sc:Canvas",
+          "label": "63v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0130.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0130.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6105,
+          "width": 4570,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0130.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0130.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0130.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4570,
+                  "height": 6105
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0130.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0131.JP2",
+          "@type": "sc:Canvas",
+          "label": "64r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0131.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0131.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 742,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 742,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4470,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0131.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0131.JP2/full/742,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 742,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0131.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4470,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0131.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0132.JP2",
+          "@type": "sc:Canvas",
+          "label": "64v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0132.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0132.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 744,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 744,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4479,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0132.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0132.JP2/full/744,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 744,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0132.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4479,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0132.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0133.JP2",
+          "@type": "sc:Canvas",
+          "label": "65r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0133.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0133.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 754,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 754,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6120,
+          "width": 4508,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0133.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0133.JP2/full/754,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 754,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0133.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4508,
+                  "height": 6120
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0133.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0134.JP2",
+          "@type": "sc:Canvas",
+          "label": "65v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0134.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0134.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6152,
+          "width": 4487,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0134.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0134.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0134.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4487,
+                  "height": 6152
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0134.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0135.JP2",
+          "@type": "sc:Canvas",
+          "label": "66r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0135.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0135.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 742,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 742,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6097,
+          "width": 4415,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0135.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0135.JP2/full/742,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 742,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0135.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4415,
+                  "height": 6097
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0135.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0136.JP2",
+          "@type": "sc:Canvas",
+          "label": "66v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0136.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0136.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6130,
+          "width": 4473,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0136.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0136.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0136.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4473,
+                  "height": 6130
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0136.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0137.JP2",
+          "@type": "sc:Canvas",
+          "label": "67r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0137.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0137.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 739,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 739,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6117,
+          "width": 4415,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0137.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0137.JP2/full/739,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0137.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4415,
+                  "height": 6117
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0137.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0138.JP2",
+          "@type": "sc:Canvas",
+          "label": "67v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0138.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0138.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 748,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 748,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6154,
+          "width": 4494,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0138.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0138.JP2/full/748,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 748,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0138.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4494,
+                  "height": 6154
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0138.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0139.JP2",
+          "@type": "sc:Canvas",
+          "label": "68r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0139.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0139.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 744,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 744,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6122,
+          "width": 4448,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0139.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0139.JP2/full/744,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 744,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0139.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4448,
+                  "height": 6122
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0139.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0140.JP2",
+          "@type": "sc:Canvas",
+          "label": "68v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0140.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0140.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 746,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 746,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6161,
+          "width": 4490,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0140.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0140.JP2/full/746,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 746,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0140.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4490,
+                  "height": 6161
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0140.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0141.JP2",
+          "@type": "sc:Canvas",
+          "label": "69r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0141.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0141.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 739,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 739,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4423,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0141.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0141.JP2/full/739,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0141.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4423,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0141.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0142.JP2",
+          "@type": "sc:Canvas",
+          "label": "69v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0142.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0142.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 751,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 293,
+                  "height": 400
+                },
+                {
+                  "width": 751,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6140,
+          "width": 4501,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0142.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0142.JP2/full/751,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 751,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0142.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4501,
+                  "height": 6140
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0142.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0143.JP2",
+          "@type": "sc:Canvas",
+          "label": "70r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0143.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0143.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6115,
+          "width": 4420,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0143.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0143.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0143.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4420,
+                  "height": 6115
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0143.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0144.JP2",
+          "@type": "sc:Canvas",
+          "label": "70v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0144.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0144.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 744,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 744,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6185,
+          "width": 4491,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0144.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0144.JP2/full/744,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 744,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0144.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4491,
+                  "height": 6185
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0144.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0145.JP2",
+          "@type": "sc:Canvas",
+          "label": "71r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0145.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0145.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 743,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 743,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4436,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0145.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0145.JP2/full/743,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 743,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0145.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4436,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0145.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0146.JP2",
+          "@type": "sc:Canvas",
+          "label": "71v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0146.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0146.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 753,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 753,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6125,
+          "width": 4504,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0146.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0146.JP2/full/753,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 753,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0146.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4504,
+                  "height": 6125
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0146.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0147.JP2",
+          "@type": "sc:Canvas",
+          "label": "72r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0147.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0147.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 747,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 292,
+                  "height": 400
+                },
+                {
+                  "width": 747,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6122,
+          "width": 4465,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0147.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0147.JP2/full/747,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 747,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0147.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4465,
+                  "height": 6122
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0147.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0148.JP2",
+          "@type": "sc:Canvas",
+          "label": "72v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0148.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0148.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6124,
+          "width": 4514,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0148.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0148.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0148.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4514,
+                  "height": 6124
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0148.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0149.JP2",
+          "@type": "sc:Canvas",
+          "label": "73r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0149.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0149.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 743,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 290,
+                  "height": 400
+                },
+                {
+                  "width": 743,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4463,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0149.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0149.JP2/full/743,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 743,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0149.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4463,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0149.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0150.JP2",
+          "@type": "sc:Canvas",
+          "label": "73v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0150.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0150.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 755,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 755,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6126,
+          "width": 4514,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0150.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0150.JP2/full/755,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 755,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0150.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4514,
+                  "height": 6126
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0150.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0151.JP2",
+          "@type": "sc:Canvas",
+          "label": "74r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0151.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0151.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 746,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 746,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4449,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0151.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0151.JP2/full/746,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 746,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0151.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4449,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0151.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0152.JP2",
+          "@type": "sc:Canvas",
+          "label": "74v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0152.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0152.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 754,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 754,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4505,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0152.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0152.JP2/full/754,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 754,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0152.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4505,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0152.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0153.JP2",
+          "@type": "sc:Canvas",
+          "label": "75r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0153.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0153.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 741,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 741,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6131,
+          "width": 4437,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0153.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0153.JP2/full/741,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 741,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0153.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4437,
+                  "height": 6131
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0153.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0154.JP2",
+          "@type": "sc:Canvas",
+          "label": "75v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0154.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0154.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 756,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 756,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6124,
+          "width": 4519,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0154.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0154.JP2/full/756,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 756,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0154.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4519,
+                  "height": 6124
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0154.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0155.JP2",
+          "@type": "sc:Canvas",
+          "label": "76r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0155.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0155.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 746,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 746,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6114,
+          "width": 4452,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0155.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0155.JP2/full/746,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 746,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0155.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4452,
+                  "height": 6114
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0155.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0156.JP2",
+          "@type": "sc:Canvas",
+          "label": "76v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0156.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0156.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 756,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 756,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6117,
+          "width": 4517,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0156.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0156.JP2/full/756,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 756,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0156.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4517,
+                  "height": 6117
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0156.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0157.JP2",
+          "@type": "sc:Canvas",
+          "label": "77r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0157.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0157.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6114,
+          "width": 4417,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0157.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0157.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0157.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4417,
+                  "height": 6114
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0157.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0158.JP2",
+          "@type": "sc:Canvas",
+          "label": "77v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0158.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0158.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 759,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 759,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6095,
+          "width": 4517,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0158.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0158.JP2/full/759,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 759,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0158.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4517,
+                  "height": 6095
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0158.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0159.JP2",
+          "@type": "sc:Canvas",
+          "label": "78r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0159.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0159.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 739,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 739,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6114,
+          "width": 4414,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0159.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0159.JP2/full/739,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0159.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4414,
+                  "height": 6114
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0159.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0160.JP2",
+          "@type": "sc:Canvas",
+          "label": "78v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0160.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0160.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 758,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 758,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6099,
+          "width": 4517,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0160.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0160.JP2/full/758,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 758,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0160.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4517,
+                  "height": 6099
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0160.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0161.JP2",
+          "@type": "sc:Canvas",
+          "label": "79r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0161.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0161.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 739,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 739,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6104,
+          "width": 4407,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0161.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0161.JP2/full/739,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0161.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4407,
+                  "height": 6104
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0161.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0162.JP2",
+          "@type": "sc:Canvas",
+          "label": "79v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0162.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0162.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 756,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 295,
+                  "height": 400
+                },
+                {
+                  "width": 756,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6122,
+          "width": 4522,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0162.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0162.JP2/full/756,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 756,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0162.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4522,
+                  "height": 6122
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0162.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0163.JP2",
+          "@type": "sc:Canvas",
+          "label": "80r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0163.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0163.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 739,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 739,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4436,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0163.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0163.JP2/full/739,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 739,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0163.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4436,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0163.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0164.JP2",
+          "@type": "sc:Canvas",
+          "label": "80v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0164.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0164.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 758,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 758,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6115,
+          "width": 4525,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0164.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0164.JP2/full/758,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 758,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0164.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4525,
+                  "height": 6115
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0164.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0165.JP2",
+          "@type": "sc:Canvas",
+          "label": "81r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0165.JP2/full/73,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0165.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 745,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 73,
+                  "height": 100
+                },
+                {
+                  "width": 146,
+                  "height": 200
+                },
+                {
+                  "width": 291,
+                  "height": 400
+                },
+                {
+                  "width": 745,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6089,
+          "width": 4431,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0165.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0165.JP2/full/745,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 745,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0165.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4431,
+                  "height": 6089
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0165.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0166.JP2",
+          "@type": "sc:Canvas",
+          "label": "81v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0166.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0166.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 763,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6106,
+          "width": 4547,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0166.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0166.JP2/full/763,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0166.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4547,
+                  "height": 6106
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0166.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0167.JP2",
+          "@type": "sc:Canvas",
+          "label": "82r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0167.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0167.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4421,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0167.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0167.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0167.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4421,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0167.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0168.JP2",
+          "@type": "sc:Canvas",
+          "label": "82v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0168.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0168.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 764,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6141,
+          "width": 4584,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0168.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0168.JP2/full/764,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0168.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4584,
+                  "height": 6141
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0168.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0169.JP2",
+          "@type": "sc:Canvas",
+          "label": "83r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0169.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0169.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 738,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 288,
+                  "height": 400
+                },
+                {
+                  "width": 738,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6095,
+          "width": 4395,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0169.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0169.JP2/full/738,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 738,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0169.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4395,
+                  "height": 6095
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0169.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0170.JP2",
+          "@type": "sc:Canvas",
+          "label": "83v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0170.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0170.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 762,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 762,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6160,
+          "width": 4583,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0170.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0170.JP2/full/762,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 762,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0170.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4583,
+                  "height": 6160
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0170.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0171.JP2",
+          "@type": "sc:Canvas",
+          "label": "84r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0171.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0171.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 736,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 736,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6100,
+          "width": 4383,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0171.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0171.JP2/full/736,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 736,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0171.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4383,
+                  "height": 6100
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0171.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0172.JP2",
+          "@type": "sc:Canvas",
+          "label": "84v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0172.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0172.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 765,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6137,
+          "width": 4583,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0172.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0172.JP2/full/765,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0172.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4583,
+                  "height": 6137
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0172.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0173.JP2",
+          "@type": "sc:Canvas",
+          "label": "85r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0173.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0173.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 730,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 730,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6125,
+          "width": 4366,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0173.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0173.JP2/full/730,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0173.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4366,
+                  "height": 6125
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0173.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0174.JP2",
+          "@type": "sc:Canvas",
+          "label": "85v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0174.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0174.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 765,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6132,
+          "width": 4583,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0174.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0174.JP2/full/765,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0174.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4583,
+                  "height": 6132
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0174.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0175.JP2",
+          "@type": "sc:Canvas",
+          "label": "86r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0175.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0175.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 732,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 286,
+                  "height": 400
+                },
+                {
+                  "width": 732,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6140,
+          "width": 4387,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0175.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0175.JP2/full/732,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 732,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0175.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4387,
+                  "height": 6140
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0175.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0176.JP2",
+          "@type": "sc:Canvas",
+          "label": "86v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0176.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0176.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 763,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6149,
+          "width": 4582,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0176.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0176.JP2/full/763,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0176.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4582,
+                  "height": 6149
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0176.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0177.JP2",
+          "@type": "sc:Canvas",
+          "label": "87r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0177.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0177.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6137,
+          "width": 4435,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0177.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0177.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0177.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4435,
+                  "height": 6137
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0177.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0178.JP2",
+          "@type": "sc:Canvas",
+          "label": "87v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0178.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0178.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 764,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6142,
+          "width": 4582,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0178.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0178.JP2/full/764,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0178.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4582,
+                  "height": 6142
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0178.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0179.JP2",
+          "@type": "sc:Canvas",
+          "label": "88r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0179.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0179.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 735,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 735,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4394,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0179.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0179.JP2/full/735,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0179.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4394,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0179.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0180.JP2",
+          "@type": "sc:Canvas",
+          "label": "88v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0180.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0180.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6106,
+          "width": 4576,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0180.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0180.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0180.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4576,
+                  "height": 6106
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0180.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0181.JP2",
+          "@type": "sc:Canvas",
+          "label": "89r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0181.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0181.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 740,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 145,
+                  "height": 200
+                },
+                {
+                  "width": 289,
+                  "height": 400
+                },
+                {
+                  "width": 740,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6081,
+          "width": 4394,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0181.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0181.JP2/full/740,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 740,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0181.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4394,
+                  "height": 6081
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0181.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0182.JP2",
+          "@type": "sc:Canvas",
+          "label": "89v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0182.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0182.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 771,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6114,
+          "width": 4603,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0182.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0182.JP2/full/771,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0182.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4603,
+                  "height": 6114
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0182.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0183.JP2",
+          "@type": "sc:Canvas",
+          "label": "90r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0183.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0183.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6140,
+          "width": 4369,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0183.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0183.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0183.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4369,
+                  "height": 6140
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0183.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0184.JP2",
+          "@type": "sc:Canvas",
+          "label": "90v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0184.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0184.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6153,
+          "width": 4604,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0184.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0184.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0184.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4604,
+                  "height": 6153
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0184.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0185.JP2",
+          "@type": "sc:Canvas",
+          "label": "91r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0185.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0185.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6111,
+          "width": 4323,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0185.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0185.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0185.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4323,
+                  "height": 6111
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0185.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0186.JP2",
+          "@type": "sc:Canvas",
+          "label": "91v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0186.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0186.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 759,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 759,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6185,
+          "width": 4584,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0186.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0186.JP2/full/759,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 759,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0186.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4584,
+                  "height": 6185
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0186.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0187.JP2",
+          "@type": "sc:Canvas",
+          "label": "92r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0187.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0187.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 735,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 735,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6109,
+          "width": 4387,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0187.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0187.JP2/full/735,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 735,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0187.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4387,
+                  "height": 6109
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0187.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0188.JP2",
+          "@type": "sc:Canvas",
+          "label": "92v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0188.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0188.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 771,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4606,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0188.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0188.JP2/full/771,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0188.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4606,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0188.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0189.JP2",
+          "@type": "sc:Canvas",
+          "label": "93r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0189.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0189.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 726,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 726,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6127,
+          "width": 4341,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0189.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0189.JP2/full/726,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 726,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0189.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4341,
+                  "height": 6127
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0189.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0190.JP2",
+          "@type": "sc:Canvas",
+          "label": "93v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0190.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0190.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6111,
+          "width": 4606,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0190.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0190.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0190.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4606,
+                  "height": 6111
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0190.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0191.JP2",
+          "@type": "sc:Canvas",
+          "label": "94r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0191.JP2/full/72,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0191.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 736,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 72,
+                  "height": 100
+                },
+                {
+                  "width": 144,
+                  "height": 200
+                },
+                {
+                  "width": 287,
+                  "height": 400
+                },
+                {
+                  "width": 736,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6084,
+          "width": 4372,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0191.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0191.JP2/full/736,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 736,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0191.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4372,
+                  "height": 6084
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0191.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0192.JP2",
+          "@type": "sc:Canvas",
+          "label": "94v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0192.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0192.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 764,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 764,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6185,
+          "width": 4615,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0192.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0192.JP2/full/764,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 764,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0192.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4615,
+                  "height": 6185
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0192.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0193.JP2",
+          "@type": "sc:Canvas",
+          "label": "95r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0193.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0193.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 731,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 731,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4387,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0193.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0193.JP2/full/731,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 731,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0193.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4387,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0193.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0194.JP2",
+          "@type": "sc:Canvas",
+          "label": "95v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0194.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0194.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 774,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6090,
+          "width": 4604,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0194.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0194.JP2/full/774,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0194.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4604,
+                  "height": 6090
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0194.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0195.JP2",
+          "@type": "sc:Canvas",
+          "label": "96r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0195.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0195.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 721,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 281,
+                  "height": 400
+                },
+                {
+                  "width": 721,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6116,
+          "width": 4304,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0195.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0195.JP2/full/721,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 721,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0195.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4304,
+                  "height": 6116
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0195.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0196.JP2",
+          "@type": "sc:Canvas",
+          "label": "96v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0196.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0196.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6093,
+          "width": 4559,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0196.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0196.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0196.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4559,
+                  "height": 6093
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0196.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0197.JP2",
+          "@type": "sc:Canvas",
+          "label": "97r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0197.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0197.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6140,
+          "width": 4372,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0197.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0197.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0197.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4372,
+                  "height": 6140
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0197.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0198.JP2",
+          "@type": "sc:Canvas",
+          "label": "97v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0198.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0198.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 753,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 147,
+                  "height": 200
+                },
+                {
+                  "width": 294,
+                  "height": 400
+                },
+                {
+                  "width": 753,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6223,
+          "width": 4579,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0198.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0198.JP2/full/753,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 753,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0198.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4579,
+                  "height": 6223
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0198.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0199.JP2",
+          "@type": "sc:Canvas",
+          "label": "98r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0199.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0199.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 730,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 730,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6145,
+          "width": 4379,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0199.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0199.JP2/full/730,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0199.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4379,
+                  "height": 6145
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0199.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0200.JP2",
+          "@type": "sc:Canvas",
+          "label": "98v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0200.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0200.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6131,
+          "width": 4598,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0200.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0200.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0200.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4598,
+                  "height": 6131
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0200.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0201.JP2",
+          "@type": "sc:Canvas",
+          "label": "99r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0201.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0201.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6137,
+          "width": 4368,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0201.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0201.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0201.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4368,
+                  "height": 6137
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0201.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0202.JP2",
+          "@type": "sc:Canvas",
+          "label": "99v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0202.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0202.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6132,
+          "width": 4601,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0202.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0202.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0202.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4601,
+                  "height": 6132
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0202.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0203.JP2",
+          "@type": "sc:Canvas",
+          "label": "100r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0203.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0203.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 729,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 729,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6141,
+          "width": 4369,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0203.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0203.JP2/full/729,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 729,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0203.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4369,
+                  "height": 6141
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0203.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0204.JP2",
+          "@type": "sc:Canvas",
+          "label": "100v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0204.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0204.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 762,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 762,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6167,
+          "width": 4592,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0204.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0204.JP2/full/762,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 762,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0204.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4592,
+                  "height": 6167
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0204.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0205.JP2",
+          "@type": "sc:Canvas",
+          "label": "101r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0205.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0205.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 730,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 730,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4354,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0205.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0205.JP2/full/730,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 730,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0205.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4354,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0205.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0206.JP2",
+          "@type": "sc:Canvas",
+          "label": "101v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0206.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0206.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6141,
+          "width": 4594,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0206.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0206.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0206.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4594,
+                  "height": 6141
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0206.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0207.JP2",
+          "@type": "sc:Canvas",
+          "label": "102r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0207.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0207.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6167,
+          "width": 4368,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0207.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0207.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0207.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4368,
+                  "height": 6167
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0207.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0208.JP2",
+          "@type": "sc:Canvas",
+          "label": "102v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0208.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0208.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 765,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6145,
+          "width": 4589,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0208.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0208.JP2/full/765,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0208.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4589,
+                  "height": 6145
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0208.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0209.JP2",
+          "@type": "sc:Canvas",
+          "label": "103r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0209.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0209.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6167,
+          "width": 4368,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0209.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0209.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0209.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4368,
+                  "height": 6167
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0209.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0210.JP2",
+          "@type": "sc:Canvas",
+          "label": "103v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0210.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0210.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6122,
+          "width": 4589,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0210.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0210.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0210.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4589,
+                  "height": 6122
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0210.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0211.JP2",
+          "@type": "sc:Canvas",
+          "label": "104r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0211.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0211.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6125,
+          "width": 4337,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0211.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0211.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0211.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4337,
+                  "height": 6125
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0211.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0212.JP2",
+          "@type": "sc:Canvas",
+          "label": "104v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0212.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0212.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 776,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 776,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4639,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0212.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0212.JP2/full/776,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 776,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0212.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4639,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0212.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0213.JP2",
+          "@type": "sc:Canvas",
+          "label": "105r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0213.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0213.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6136,
+          "width": 4340,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0213.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0213.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0213.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4340,
+                  "height": 6136
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0213.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0214.JP2",
+          "@type": "sc:Canvas",
+          "label": "105v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0214.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0214.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 775,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 775,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4624,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0214.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0214.JP2/full/775,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 775,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0214.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4624,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0214.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0215.JP2",
+          "@type": "sc:Canvas",
+          "label": "106r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0215.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0215.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 716,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4312,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0215.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0215.JP2/full/716,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0215.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4312,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0215.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0216.JP2",
+          "@type": "sc:Canvas",
+          "label": "106v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0216.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0216.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6183,
+          "width": 4637,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0216.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0216.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0216.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4637,
+                  "height": 6183
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0216.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0217.JP2",
+          "@type": "sc:Canvas",
+          "label": "107r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0217.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0217.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4331,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0217.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0217.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0217.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4331,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0217.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0218.JP2",
+          "@type": "sc:Canvas",
+          "label": "107v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0218.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0218.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6184,
+          "width": 4630,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0218.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0218.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0218.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4630,
+                  "height": 6184
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0218.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0219.JP2",
+          "@type": "sc:Canvas",
+          "label": "108r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0219.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0219.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 715,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 715,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6147,
+          "width": 4293,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0219.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0219.JP2/full/715,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 715,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0219.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4293,
+                  "height": 6147
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0219.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0220.JP2",
+          "@type": "sc:Canvas",
+          "label": "108v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0220.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0220.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 770,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6133,
+          "width": 4611,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0220.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0220.JP2/full/770,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0220.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4611,
+                  "height": 6133
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0220.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0221.JP2",
+          "@type": "sc:Canvas",
+          "label": "109r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0221.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0221.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 714,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 714,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6112,
+          "width": 4262,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0221.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0221.JP2/full/714,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 714,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0221.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4262,
+                  "height": 6112
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0221.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0222.JP2",
+          "@type": "sc:Canvas",
+          "label": "109v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0222.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0222.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 769,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6135,
+          "width": 4609,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0222.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0222.JP2/full/769,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0222.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4609,
+                  "height": 6135
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0222.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0223.JP2",
+          "@type": "sc:Canvas",
+          "label": "110r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0223.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0223.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 708,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 708,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6101,
+          "width": 4218,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0223.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0223.JP2/full/708,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 708,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0223.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4218,
+                  "height": 6101
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0223.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0224.JP2",
+          "@type": "sc:Canvas",
+          "label": "110v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0224.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0224.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 774,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6126,
+          "width": 4629,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0224.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0224.JP2/full/774,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0224.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4629,
+                  "height": 6126
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0224.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0225.JP2",
+          "@type": "sc:Canvas",
+          "label": "111r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0225.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0225.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 714,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 714,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6106,
+          "width": 4258,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0225.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0225.JP2/full/714,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 714,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0225.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4258,
+                  "height": 6106
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0225.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0226.JP2",
+          "@type": "sc:Canvas",
+          "label": "111v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0226.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0226.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 773,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6127,
+          "width": 4624,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0226.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0226.JP2/full/773,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0226.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4624,
+                  "height": 6127
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0226.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0227.JP2",
+          "@type": "sc:Canvas",
+          "label": "112r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0227.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0227.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 714,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 714,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4271,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0227.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0227.JP2/full/714,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 714,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0227.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4271,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0227.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0228.JP2",
+          "@type": "sc:Canvas",
+          "label": "112v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0228.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0228.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 774,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6121,
+          "width": 4626,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0228.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0228.JP2/full/774,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0228.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4626,
+                  "height": 6121
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0228.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0229.JP2",
+          "@type": "sc:Canvas",
+          "label": "113r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0229.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0229.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 728,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 728,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6167,
+          "width": 4387,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0229.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0229.JP2/full/728,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 728,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0229.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4387,
+                  "height": 6167
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0229.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0230.JP2",
+          "@type": "sc:Canvas",
+          "label": "113v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0230.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0230.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 770,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6150,
+          "width": 4626,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0230.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0230.JP2/full/770,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0230.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4626,
+                  "height": 6150
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0230.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0231.JP2",
+          "@type": "sc:Canvas",
+          "label": "114r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0231.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0231.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4368,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0231.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0231.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0231.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4368,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0231.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0232.JP2",
+          "@type": "sc:Canvas",
+          "label": "114v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0232.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0232.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 773,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6134,
+          "width": 4632,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0232.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0232.JP2/full/773,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0232.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4632,
+                  "height": 6134
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0232.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0233.JP2",
+          "@type": "sc:Canvas",
+          "label": "115r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0233.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0233.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6147,
+          "width": 4350,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0233.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0233.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0233.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4350,
+                  "height": 6147
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0233.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0234.JP2",
+          "@type": "sc:Canvas",
+          "label": "115v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0234.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0234.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 769,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6158,
+          "width": 4623,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0234.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0234.JP2/full/769,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0234.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4623,
+                  "height": 6158
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0234.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0235.JP2",
+          "@type": "sc:Canvas",
+          "label": "116r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0235.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0235.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 724,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 724,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6106,
+          "width": 4315,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0235.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0235.JP2/full/724,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 724,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0235.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4315,
+                  "height": 6106
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0235.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0236.JP2",
+          "@type": "sc:Canvas",
+          "label": "116v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0236.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0236.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6125,
+          "width": 4617,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0236.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0236.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0236.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4617,
+                  "height": 6125
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0236.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0237.JP2",
+          "@type": "sc:Canvas",
+          "label": "117r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0237.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0237.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 731,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 143,
+                  "height": 200
+                },
+                {
+                  "width": 285,
+                  "height": 400
+                },
+                {
+                  "width": 731,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4387,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0237.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0237.JP2/full/731,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 731,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0237.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4387,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0237.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0238.JP2",
+          "@type": "sc:Canvas",
+          "label": "117v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0238.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0238.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 773,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6137,
+          "width": 4630,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0238.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0238.JP2/full/773,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0238.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4630,
+                  "height": 6137
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0238.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0239.JP2",
+          "@type": "sc:Canvas",
+          "label": "118r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0239.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0239.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 717,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 717,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4303,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0239.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0239.JP2/full/717,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 717,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0239.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4303,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0239.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0240.JP2",
+          "@type": "sc:Canvas",
+          "label": "118v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0240.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0240.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6125,
+          "width": 4615,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0240.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0240.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0240.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4615,
+                  "height": 6125
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0240.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0241.JP2",
+          "@type": "sc:Canvas",
+          "label": "119r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0241.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0241.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 725,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 283,
+                  "height": 400
+                },
+                {
+                  "width": 725,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6121,
+          "width": 4331,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0241.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0241.JP2/full/725,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 725,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0241.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4331,
+                  "height": 6121
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0241.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0242.JP2",
+          "@type": "sc:Canvas",
+          "label": "119v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0242.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0242.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 776,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 303,
+                  "height": 400
+                },
+                {
+                  "width": 776,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4673,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0242.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0242.JP2/full/776,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 776,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0242.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4673,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0242.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0243.JP2",
+          "@type": "sc:Canvas",
+          "label": "120r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0243.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0243.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 726,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 726,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6112,
+          "width": 4333,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0243.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0243.JP2/full/726,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 726,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0243.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4333,
+                  "height": 6112
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0243.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0244.JP2",
+          "@type": "sc:Canvas",
+          "label": "120v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0244.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0244.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6210,
+          "width": 4651,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0244.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0244.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0244.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4651,
+                  "height": 6210
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0244.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0245.JP2",
+          "@type": "sc:Canvas",
+          "label": "121r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0245.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0245.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 727,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 727,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4335,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0245.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0245.JP2/full/727,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 727,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0245.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4335,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0245.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0246.JP2",
+          "@type": "sc:Canvas",
+          "label": "121v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0246.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0246.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6217,
+          "width": 4653,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0246.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0246.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0246.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4653,
+                  "height": 6217
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0246.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0247.JP2",
+          "@type": "sc:Canvas",
+          "label": "122r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0247.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0247.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 728,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 728,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4368,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0247.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0247.JP2/full/728,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 728,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0247.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4368,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0247.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0248.JP2",
+          "@type": "sc:Canvas",
+          "label": "122v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0248.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0248.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6175,
+          "width": 4653,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0248.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0248.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0248.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4653,
+                  "height": 6175
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0248.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0249.JP2",
+          "@type": "sc:Canvas",
+          "label": "123r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0249.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0249.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 720,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 281,
+                  "height": 400
+                },
+                {
+                  "width": 720,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6098,
+          "width": 4290,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0249.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0249.JP2/full/720,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 720,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0249.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4290,
+                  "height": 6098
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0249.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0250.JP2",
+          "@type": "sc:Canvas",
+          "label": "123v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0250.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0250.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 777,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 152,
+                  "height": 200
+                },
+                {
+                  "width": 304,
+                  "height": 400
+                },
+                {
+                  "width": 777,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6169,
+          "width": 4682,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0250.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0250.JP2/full/777,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 777,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0250.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4682,
+                  "height": 6169
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0250.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0251.JP2",
+          "@type": "sc:Canvas",
+          "label": "124r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0251.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0251.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 715,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 715,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6097,
+          "width": 4259,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0251.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0251.JP2/full/715,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 715,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0251.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4259,
+                  "height": 6097
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0251.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0252.JP2",
+          "@type": "sc:Canvas",
+          "label": "124v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0252.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0252.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 773,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 773,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6162,
+          "width": 4649,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0252.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0252.JP2/full/773,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 773,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0252.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4649,
+                  "height": 6162
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0252.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0253.JP2",
+          "@type": "sc:Canvas",
+          "label": "125r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0253.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0253.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 716,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6092,
+          "width": 4260,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0253.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0253.JP2/full/716,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0253.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4260,
+                  "height": 6092
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0253.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0254.JP2",
+          "@type": "sc:Canvas",
+          "label": "125v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0254.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0254.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6175,
+          "width": 4632,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0254.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0254.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0254.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4632,
+                  "height": 6175
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0254.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0255.JP2",
+          "@type": "sc:Canvas",
+          "label": "126r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0255.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0255.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 716,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6096,
+          "width": 4262,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0255.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0255.JP2/full/716,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0255.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4262,
+                  "height": 6096
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0255.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0256.JP2",
+          "@type": "sc:Canvas",
+          "label": "126v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0256.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0256.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6181,
+          "width": 4659,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0256.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0256.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0256.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4659,
+                  "height": 6181
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0256.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0257.JP2",
+          "@type": "sc:Canvas",
+          "label": "127r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0257.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0257.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 713,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 713,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6107,
+          "width": 4251,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0257.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0257.JP2/full/713,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 713,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0257.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4251,
+                  "height": 6107
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0257.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0258.JP2",
+          "@type": "sc:Canvas",
+          "label": "127v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0258.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0258.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6174,
+          "width": 4619,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0258.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0258.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0258.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4619,
+                  "height": 6174
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0258.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0259.JP2",
+          "@type": "sc:Canvas",
+          "label": "128r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0259.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0259.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 717,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 717,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4293,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0259.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0259.JP2/full/717,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 717,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0259.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4293,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0259.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0260.JP2",
+          "@type": "sc:Canvas",
+          "label": "128v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0260.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0260.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 770,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6173,
+          "width": 4642,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0260.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0260.JP2/full/770,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0260.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4642,
+                  "height": 6173
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0260.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0261.JP2",
+          "@type": "sc:Canvas",
+          "label": "129r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0261.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0261.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 716,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 140,
+                  "height": 200
+                },
+                {
+                  "width": 280,
+                  "height": 400
+                },
+                {
+                  "width": 716,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4312,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0261.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0261.JP2/full/716,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 716,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0261.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4312,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0261.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0262.JP2",
+          "@type": "sc:Canvas",
+          "label": "129v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0262.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0262.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 765,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 765,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6216,
+          "width": 4645,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0262.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0262.JP2/full/765,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 765,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0262.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4645,
+                  "height": 6216
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0262.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0263.JP2",
+          "@type": "sc:Canvas",
+          "label": "130r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0263.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0263.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 708,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 708,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4237,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0263.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0263.JP2/full/708,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 708,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0263.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4237,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0263.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0264.JP2",
+          "@type": "sc:Canvas",
+          "label": "130v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0264.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0264.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6202,
+          "width": 4645,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0264.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0264.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0264.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4645,
+                  "height": 6202
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0264.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0265.JP2",
+          "@type": "sc:Canvas",
+          "label": "131r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0265.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0265.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 709,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 709,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6148,
+          "width": 4256,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0265.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0265.JP2/full/709,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 709,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0265.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4256,
+                  "height": 6148
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0265.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0266.JP2",
+          "@type": "sc:Canvas",
+          "label": "131v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0266.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0266.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6202,
+          "width": 4646,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0266.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0266.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0266.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4646,
+                  "height": 6202
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0266.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0267.JP2",
+          "@type": "sc:Canvas",
+          "label": "132r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0267.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0267.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 711,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 711,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6129,
+          "width": 4256,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0267.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0267.JP2/full/711,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 711,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0267.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4256,
+                  "height": 6129
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0267.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0268.JP2",
+          "@type": "sc:Canvas",
+          "label": "132v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0268.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0268.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6208,
+          "width": 4649,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0268.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0268.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0268.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4649,
+                  "height": 6208
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0268.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0269.JP2",
+          "@type": "sc:Canvas",
+          "label": "133r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0269.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0269.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 707,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 707,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6167,
+          "width": 4256,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0269.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0269.JP2/full/707,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 707,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0269.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4256,
+                  "height": 6167
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0269.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0270.JP2",
+          "@type": "sc:Canvas",
+          "label": "133v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0270.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0270.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 770,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6183,
+          "width": 4650,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0270.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0270.JP2/full/770,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0270.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4650,
+                  "height": 6183
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0270.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0271.JP2",
+          "@type": "sc:Canvas",
+          "label": "134r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0271.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0271.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 709,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 709,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6097,
+          "width": 4224,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0271.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0271.JP2/full/709,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 709,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0271.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4224,
+                  "height": 6097
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0271.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0272.JP2",
+          "@type": "sc:Canvas",
+          "label": "134v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0272.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0272.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6196,
+          "width": 4650,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0272.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0272.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0272.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4650,
+                  "height": 6196
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0272.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0273.JP2",
+          "@type": "sc:Canvas",
+          "label": "135r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0273.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0273.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 706,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 706,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6096,
+          "width": 4200,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0273.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0273.JP2/full/706,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 706,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0273.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4200,
+                  "height": 6096
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0273.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0274.JP2",
+          "@type": "sc:Canvas",
+          "label": "135v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0274.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0274.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6198,
+          "width": 4650,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0274.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0274.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0274.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4650,
+                  "height": 6198
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0274.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0275.JP2",
+          "@type": "sc:Canvas",
+          "label": "136r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0275.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0275.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 706,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 706,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6103,
+          "width": 4206,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0275.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0275.JP2/full/706,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 706,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0275.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4206,
+                  "height": 6103
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0275.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0276.JP2",
+          "@type": "sc:Canvas",
+          "label": "136v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0276.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0276.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6223,
+          "width": 4658,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0276.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0276.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0276.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4658,
+                  "height": 6223
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0276.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0277.JP2",
+          "@type": "sc:Canvas",
+          "label": "137r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0277.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0277.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 705,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 275,
+                  "height": 400
+                },
+                {
+                  "width": 705,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6110,
+          "width": 4204,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0277.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0277.JP2/full/705,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 705,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0277.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4204,
+                  "height": 6110
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0277.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0278.JP2",
+          "@type": "sc:Canvas",
+          "label": "137v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0278.JP2/full/76,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0278.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 774,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 76,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 302,
+                  "height": 400
+                },
+                {
+                  "width": 774,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6166,
+          "width": 4660,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0278.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0278.JP2/full/774,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 774,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0278.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4660,
+                  "height": 6166
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0278.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0279.JP2",
+          "@type": "sc:Canvas",
+          "label": "138r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0279.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0279.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 710,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 710,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6097,
+          "width": 4226,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0279.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0279.JP2/full/710,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 710,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0279.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4226,
+                  "height": 6097
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0279.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0280.JP2",
+          "@type": "sc:Canvas",
+          "label": "138v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0280.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0280.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6211,
+          "width": 4660,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0280.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0280.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0280.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4660,
+                  "height": 6211
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0280.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0281.JP2",
+          "@type": "sc:Canvas",
+          "label": "139r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0281.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0281.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 707,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 707,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6100,
+          "width": 4210,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0281.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0281.JP2/full/707,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 707,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0281.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4210,
+                  "height": 6100
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0281.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0282.JP2",
+          "@type": "sc:Canvas",
+          "label": "139v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0282.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0282.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 768,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 768,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6212,
+          "width": 4658,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0282.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0282.JP2/full/768,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 768,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0282.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4658,
+                  "height": 6212
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0282.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0283.JP2",
+          "@type": "sc:Canvas",
+          "label": "140r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0283.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0283.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 707,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 707,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6108,
+          "width": 4220,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0283.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0283.JP2/full/707,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 707,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0283.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4220,
+                  "height": 6108
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0283.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0284.JP2",
+          "@type": "sc:Canvas",
+          "label": "140v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0284.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0284.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 766,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 766,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6233,
+          "width": 4661,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0284.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0284.JP2/full/766,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 766,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0284.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4661,
+                  "height": 6233
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0284.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0285.JP2",
+          "@type": "sc:Canvas",
+          "label": "141r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0285.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0285.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 708,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 708,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6092,
+          "width": 4213,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0285.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0285.JP2/full/708,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 708,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0285.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4213,
+                  "height": 6092
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0285.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0286.JP2",
+          "@type": "sc:Canvas",
+          "label": "141v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0286.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0286.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 769,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 769,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6218,
+          "width": 4670,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0286.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0286.JP2/full/769,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 769,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0286.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4670,
+                  "height": 6218
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0286.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0287.JP2",
+          "@type": "sc:Canvas",
+          "label": "142r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0287.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0287.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 710,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 710,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6103,
+          "width": 4229,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0287.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0287.JP2/full/710,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 710,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0287.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4229,
+                  "height": 6103
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0287.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0288.JP2",
+          "@type": "sc:Canvas",
+          "label": "142v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0288.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0288.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 771,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6253,
+          "width": 4710,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0288.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0288.JP2/full/771,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0288.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4710,
+                  "height": 6253
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0288.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0289.JP2",
+          "@type": "sc:Canvas",
+          "label": "143r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0289.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0289.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 709,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 709,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6119,
+          "width": 4234,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0289.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0289.JP2/full/709,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 709,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0289.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4234,
+                  "height": 6119
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0289.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0290.JP2",
+          "@type": "sc:Canvas",
+          "label": "143v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0290.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0290.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 758,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 758,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6256,
+          "width": 4632,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0290.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0290.JP2/full/758,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 758,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0290.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4632,
+                  "height": 6256
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0290.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0291.JP2",
+          "@type": "sc:Canvas",
+          "label": "144r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0291.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0291.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 714,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 714,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6079,
+          "width": 4237,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0291.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0291.JP2/full/714,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 714,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0291.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4237,
+                  "height": 6079
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0291.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0292.JP2",
+          "@type": "sc:Canvas",
+          "label": "144v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0292.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0292.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 757,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 148,
+                  "height": 200
+                },
+                {
+                  "width": 296,
+                  "height": 400
+                },
+                {
+                  "width": 757,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6281,
+          "width": 4641,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0292.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0292.JP2/full/757,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 757,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0292.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4641,
+                  "height": 6281
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0292.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0293.JP2",
+          "@type": "sc:Canvas",
+          "label": "145r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0293.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0293.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 712,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 712,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6092,
+          "width": 4235,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0293.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0293.JP2/full/712,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 712,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0293.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4235,
+                  "height": 6092
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0293.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0294.JP2",
+          "@type": "sc:Canvas",
+          "label": "145v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0294.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0294.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 761,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 297,
+                  "height": 400
+                },
+                {
+                  "width": 761,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6269,
+          "width": 4659,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0294.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0294.JP2/full/761,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 761,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0294.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4659,
+                  "height": 6269
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0294.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0295.JP2",
+          "@type": "sc:Canvas",
+          "label": "146r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0295.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0295.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 713,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 713,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6109,
+          "width": 4252,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0295.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0295.JP2/full/713,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 713,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0295.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4252,
+                  "height": 6109
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0295.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0296.JP2",
+          "@type": "sc:Canvas",
+          "label": "146v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0296.JP2/full/74,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0296.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 763,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 74,
+                  "height": 100
+                },
+                {
+                  "width": 149,
+                  "height": 200
+                },
+                {
+                  "width": 298,
+                  "height": 400
+                },
+                {
+                  "width": 763,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6264,
+          "width": 4666,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0296.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0296.JP2/full/763,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 763,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0296.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4666,
+                  "height": 6264
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0296.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0297.JP2",
+          "@type": "sc:Canvas",
+          "label": "147r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0297.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0297.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 709,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 277,
+                  "height": 400
+                },
+                {
+                  "width": 709,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6112,
+          "width": 4233,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0297.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0297.JP2/full/709,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 709,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0297.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4233,
+                  "height": 6112
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0297.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0298.JP2",
+          "@type": "sc:Canvas",
+          "label": "147v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0298.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0298.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6209,
+          "width": 4678,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0298.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0298.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0298.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4678,
+                  "height": 6209
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0298.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0299.JP2",
+          "@type": "sc:Canvas",
+          "label": "148r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0299.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0299.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 713,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 713,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6079,
+          "width": 4232,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0299.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0299.JP2/full/713,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 713,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0299.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4232,
+                  "height": 6079
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0299.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0300.JP2",
+          "@type": "sc:Canvas",
+          "label": "148v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0300.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0300.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 300,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6251,
+          "width": 4685,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0300.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0300.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0300.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4685,
+                  "height": 6251
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0300.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0301.JP2",
+          "@type": "sc:Canvas",
+          "label": "149r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0301.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0301.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 714,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 279,
+                  "height": 400
+                },
+                {
+                  "width": 714,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6084,
+          "width": 4240,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0301.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0301.JP2/full/714,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 714,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0301.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4240,
+                  "height": 6084
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0301.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0302.JP2",
+          "@type": "sc:Canvas",
+          "label": "149v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0302.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0302.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 767,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 299,
+                  "height": 400
+                },
+                {
+                  "width": 767,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6249,
+          "width": 4678,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0302.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0302.JP2/full/767,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 767,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0302.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4678,
+                  "height": 6249
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0302.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0303.JP2",
+          "@type": "sc:Canvas",
+          "label": "150r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0303.JP2/full/70,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0303.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 712,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 70,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 712,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6093,
+          "width": 4238,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0303.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0303.JP2/full/712,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 712,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0303.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4238,
+                  "height": 6093
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0303.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0304.JP2",
+          "@type": "sc:Canvas",
+          "label": "150v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0304.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0304.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 771,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 771,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6226,
+          "width": 4685,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0304.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0304.JP2/full/771,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 771,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0304.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4685,
+                  "height": 6226
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0304.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0305.JP2",
+          "@type": "sc:Canvas",
+          "label": "151r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0305.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0305.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 706,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 706,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6103,
+          "width": 4208,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0305.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0305.JP2/full/706,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 706,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0305.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4208,
+                  "height": 6103
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0305.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0306.JP2",
+          "@type": "sc:Canvas",
+          "label": "151v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0306.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0306.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6233,
+          "width": 4698,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0306.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0306.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0306.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4698,
+                  "height": 6233
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0306.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0307.JP2",
+          "@type": "sc:Canvas",
+          "label": "152r",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0307.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0307.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 706,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 706,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6085,
+          "width": 4193,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0307.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0307.JP2/full/706,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 706,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0307.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4193,
+                  "height": 6085
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0307.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0308.JP2",
+          "@type": "sc:Canvas",
+          "label": "152v",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0308.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0308.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 772,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 151,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 772,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6218,
+          "width": 4685,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0308.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0308.JP2/full/772,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 772,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0308.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4685,
+                  "height": 6218
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0308.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0309.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0309.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0309.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 702,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 137,
+                  "height": 200
+                },
+                {
+                  "width": 274,
+                  "height": 400
+                },
+                {
+                  "width": 702,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6112,
+          "width": 4191,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0309.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0309.JP2/full/702,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 702,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0309.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4191,
+                  "height": 6112
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0309.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0310.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0310.JP2/full/75,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0310.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 770,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 75,
+                  "height": 100
+                },
+                {
+                  "width": 150,
+                  "height": 200
+                },
+                {
+                  "width": 301,
+                  "height": 400
+                },
+                {
+                  "width": 770,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6225,
+          "width": 4681,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0310.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0310.JP2/full/770,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 770,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0310.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4681,
+                  "height": 6225
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0310.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0311.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0311.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0311.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 707,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 138,
+                  "height": 200
+                },
+                {
+                  "width": 276,
+                  "height": 400
+                },
+                {
+                  "width": 707,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6090,
+          "width": 4207,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0311.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0311.JP2/full/707,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 707,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0311.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4207,
+                  "height": 6090
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0311.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0312.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0312.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0312.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 727,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 142,
+                  "height": 200
+                },
+                {
+                  "width": 284,
+                  "height": 400
+                },
+                {
+                  "width": 727,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6879,
+          "width": 4883,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0312.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0312.JP2/full/727,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 727,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0312.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4883,
+                  "height": 6879
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0312.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0313.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0313.JP2/full/19,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0313.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 194,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 19,
+                  "height": 100
+                },
+                {
+                  "width": 38,
+                  "height": 200
+                },
+                {
+                  "width": 76,
+                  "height": 400
+                },
+                {
+                  "width": 194,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 7414,
+          "width": 1407,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0313.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0313.JP2/full/194,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 194,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0313.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 1407,
+                  "height": 7414
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0313.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0314.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0314.JP2/full/25,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0314.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 252,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 25,
+                  "height": 100
+                },
+                {
+                  "width": 49,
+                  "height": 200
+                },
+                {
+                  "width": 98,
+                  "height": 400
+                },
+                {
+                  "width": 252,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 7441,
+          "width": 1830,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0314.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0314.JP2/full/252,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 252,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0314.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 1830,
+                  "height": 7441
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0314.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0315.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0315.JP2/full/100,33/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0315.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 1024,
+              "height": 341,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 33
+                },
+                {
+                  "width": 200,
+                  "height": 67
+                },
+                {
+                  "width": 400,
+                  "height": 133
+                },
+                {
+                  "width": 1024,
+                  "height": 341
+                }
+              ]
+            }
+          },
+          "height": 1949,
+          "width": 5856,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0315.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0315.JP2/full/1024,341/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 341,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0315.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 5856,
+                  "height": 1949
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0315.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0316.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0316.JP2/full/100,31/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0316.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 1024,
+              "height": 313,
+              "sizes": [
+                {
+                  "width": 100,
+                  "height": 31
+                },
+                {
+                  "width": 200,
+                  "height": 61
+                },
+                {
+                  "width": 400,
+                  "height": 122
+                },
+                {
+                  "width": 1024,
+                  "height": 313
+                }
+              ]
+            }
+          },
+          "height": 1779,
+          "width": 5814,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0316.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0316.JP2/full/1024,313/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 313,
+                "width": 1024,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0316.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 5814,
+                  "height": 1779
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0316.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0317.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0317.JP2/full/71,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0317.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 723,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 71,
+                  "height": 100
+                },
+                {
+                  "width": 141,
+                  "height": 200
+                },
+                {
+                  "width": 282,
+                  "height": 400
+                },
+                {
+                  "width": 723,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6932,
+          "width": 4893,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0317.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0317.JP2/full/723,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 723,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0317.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4893,
+                  "height": 6932
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0317.JP2"
+            }
+          ],
+          "within": ""
+        },
+        {
+          "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0318.JP2",
+          "@type": "sc:Canvas",
+          "label": "-",
+          "thumbnail": {
+            "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0318.JP2/full/69,100/0/default.jpg",
+            "@type": "dctypes:Image",
+            "service": {
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id": "https://iiif.wellcomecollection.org/thumbs/b19646045_ms_573_0318.JP2",
+              "profile": "http://iiif.io/api/image/2/level0.json",
+              "protocol": "http://iiif.io/api/image",
+              "width": 712,
+              "height": 1024,
+              "sizes": [
+                {
+                  "width": 69,
+                  "height": 100
+                },
+                {
+                  "width": 139,
+                  "height": 200
+                },
+                {
+                  "width": 278,
+                  "height": 400
+                },
+                {
+                  "width": 712,
+                  "height": 1024
+                }
+              ]
+            }
+          },
+          "height": 6296,
+          "width": 4375,
+          "images": [
+            {
+              "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0318.JP2/painting/anno",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "resource": {
+                "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0318.JP2/full/712,1024/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "height": 1024,
+                "width": 712,
+                "service": {
+                  "@context": "http://iiif.io/api/image/2/context.json",
+                  "@id": "https://iiif.wellcomecollection.org/image/b19646045_ms_573_0318.JP2",
+                  "profile": "http://iiif.io/api/image/2/level1.json",
+                  "protocol": "http://iiif.io/api/image",
+                  "width": 4375,
+                  "height": 6296
+                }
+              },
+              "on": "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0318.JP2"
+            }
+          ],
+          "within": ""
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0002",
+      "@type": "sc:Range",
+      "label": "Cover",
+      "canvases": ["https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0001.JP2"],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0003",
+      "@type": "sc:Range",
+      "label": "'Precatio terrae matris,' abbreviated and corrupted",
+      "canvases": ["https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0005.JP2"],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0004",
+      "@type": "sc:Range",
+      "label": "'Precatio omnium herbarum,' abbreviated and corrupted",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0005.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0006.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0007.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0008.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0009.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0010.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0005",
+      "@type": "sc:Range",
+      "label": "Antonius Musa, 'De herba vettonica'",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0010.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0011.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0012.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0013.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0014.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0015.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0006",
+      "@type": "sc:Range",
+      "label": "Pseudo-Apuleius, 'Herbarius'",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0016.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0017.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0018.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0019.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0020.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0021.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0022.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0023.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0024.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0025.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0026.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0027.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0028.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0029.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0030.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0031.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0032.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0033.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0034.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0035.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0036.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0037.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0038.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0039.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0040.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0041.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0042.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0043.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0044.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0045.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0046.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0047.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0048.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0049.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0050.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0051.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0052.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0053.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0054.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0055.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0056.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0057.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0058.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0059.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0060.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0061.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0062.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0063.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0064.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0065.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0066.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0067.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0068.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0069.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0070.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0071.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0072.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0073.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0074.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0075.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0076.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0077.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0007",
+      "@type": "sc:Range",
+      "label": "Anonymous, 'De taxone'",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0078.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0079.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0080.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0008",
+      "@type": "sc:Range",
+      "label": "Sextus Placitus, 'De medicina ex animalibus,' (continues at f.76r)",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0080.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0081.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0082.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0083.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0084.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0085.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0086.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0087.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0088.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0089.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0090.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0091.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0092.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0093.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0094.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0095.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0096.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0009",
+      "@type": "sc:Range",
+      "label": "'Curae herbarum,' interpolated within the Sextus Placitus herbal",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0096.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0097.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0098.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0099.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0100.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0101.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0102.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0103.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0104.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0105.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0106.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0107.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0108.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0109.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0110.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0111.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0112.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0113.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0114.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0115.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0116.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0117.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0118.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0119.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0120.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0121.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0122.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0123.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0124.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0125.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0126.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0127.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0128.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0129.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0130.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0131.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0132.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0133.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0134.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0135.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0136.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0137.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0138.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0139.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0140.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0010",
+      "@type": "sc:Range",
+      "label": "Receipts, interpolated within the Sextus Placitus herbal",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0140.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0141.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0142.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0143.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0144.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0145.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0146.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0147.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0148.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0149.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0150.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0151.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0152.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0153.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0011",
+      "@type": "sc:Range",
+      "label": "Illustration",
+      "canvases": ["https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0154.JP2"],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0012",
+      "@type": "sc:Range",
+      "label": "Sextus Placitus, 'De medicina ex animalibus,' (continued from f.46v)",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0155.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0156.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0157.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0158.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0159.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0160.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0161.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0162.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0163.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0164.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0165.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0166.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0167.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0168.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0169.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0170.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0171.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0172.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0173.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0174.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0175.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0176.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0177.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0178.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0179.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0180.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0181.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0182.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0183.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0184.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0185.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0186.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0187.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0188.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0189.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0190.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0191.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0192.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0193.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0194.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0195.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0196.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0197.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0198.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0199.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0200.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0201.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0202.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0203.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0204.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0205.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0206.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0207.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0208.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0209.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0210.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0211.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0212.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0213.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0214.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0215.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0216.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0217.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0218.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0219.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0220.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0221.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0222.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0223.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0224.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0225.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0226.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0227.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0228.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0229.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0230.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0231.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0232.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0233.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0234.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0235.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0236.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0237.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0238.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0239.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0240.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0241.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0242.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0243.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0244.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0245.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0246.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0247.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0248.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0249.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0250.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0251.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0252.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0253.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0254.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0255.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0256.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0257.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0258.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0259.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0260.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0261.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0262.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0263.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0264.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0265.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0266.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0267.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0268.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0269.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0270.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0271.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0272.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0273.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0274.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0275.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0276.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0277.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0278.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0279.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0280.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0281.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0282.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0283.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0284.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0285.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0286.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0287.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0288.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0289.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0290.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0291.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0292.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0293.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0294.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0295.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0296.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0297.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0298.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0299.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0300.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0301.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0302.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0013",
+      "@type": "sc:Range",
+      "label": "Relation of a cure of a friend of the scribe",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0303.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0304.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0305.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0014",
+      "@type": "sc:Range",
+      "label": "Tables of Roman and Arabic numerals from 1 to 1,000,000",
+      "canvases": [
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0306.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0307.JP2",
+        "https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0308.JP2"
+      ],
+      "within": ""
+    },
+    {
+      "@id": "https://iiif.wellcomecollection.org/presentation/b19646045/ranges/LOG_0015",
+      "@type": "sc:Range",
+      "label": "Cover",
+      "canvases": ["https://iiif.wellcomecollection.org/presentation/b19646045/canvases/b19646045_ms_573_0313.JP2"],
+      "within": ""
+    }
+  ],
+  "within": "https://iiif.wellcomecollection.org/presentation/v2/collections/subjects/Materia_Medica"
+}

--- a/fixtures/presentation-3/bl-av-manifest.json
+++ b/fixtures/presentation-3/bl-av-manifest.json
@@ -1,0 +1,3557 @@
+{
+  "@context": ["http://iiif.io/api/auth/1/context.json", "http://iiif.io/api/presentation/3/context.json"],
+  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/manifest.json",
+  "type": "Manifest",
+  "label": {
+    "en": ["C604/16 C604/17 Wiltshire and Dorset, dub of disks / Fanny Rumble, A. Collins, Perrier"]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": ["Full title"]
+      },
+      "value": {
+        "en": ["Wiltshire and Dorset, dub of disks / Fanny Rumble, A. Collins, Perrier"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Collection"]
+      },
+      "value": {
+        "en": ["Peter Kennedy Collection"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Format"]
+      },
+      "value": {
+        "en": ["1 tape reel 18 cm 19 cm/sec 1 tape reel 18 cm 19 cm/sec and 38 cm/sec"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Usage"]
+      },
+      "value": {
+        "en": ["<span>Rights unassigned - staff access only</span>"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Held by"]
+      },
+      "value": {
+        "en": ["The British Library"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Digitised by"]
+      },
+      "value": {
+        "en": ["The British Library, 2018"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Digitisation funded by"]
+      },
+      "value": {
+        "en": [
+          "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": ["Identifier"]
+      },
+      "value": {
+        "en": ["C604/16-C604/17"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Shelfmark"]
+      },
+      "value": {
+        "en": ["C604/16", "C604/17"]
+      }
+    },
+    {
+      "label": {
+        "en": ["Link to catalogue"]
+      },
+      "value": {
+        "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA7608156'>View the catalogue record</a>"]
+      }
+    }
+  ],
+  "requiredStatement": {
+    "label": {
+      "en": ["Usage"]
+    },
+    "value": {
+      "en": [
+        "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA7608156\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https://www.bl.uk/about-us",
+      "type": "Agent",
+      "label": {
+        "en": ["The British Library"]
+      },
+      "homepage": [
+        {
+          "id": "https://www.bl.uk/",
+          "type": "Text",
+          "format": "text/html",
+          "label": {
+            "en": ["The British Library"]
+          }
+        }
+      ],
+      "logo": [
+        {
+          "id": "https://www.bl.uk/images/bl_logo_100.gif",
+          "type": "Image",
+          "format": "image/gif"
+        }
+      ]
+    }
+  ],
+  "service": [
+    {
+      "id": "https://api.bl.uk/auth/iiif/login",
+      "type": "AuthCookieService1",
+      "profile": "http://iiif.io/api/auth/1/login",
+      "description": "Some portions of this recording may be unavailable due to rights restrictions.",
+      "header": "Please Log-In",
+      "label": "Login to The British Library",
+      "service": [
+        {
+          "id": "https://api.bl.uk/auth/iiif/token",
+          "type": "AuthTokenService1",
+          "profile": "http://iiif.io/api/auth/1/token"
+        }
+      ]
+    },
+    {
+      "id": "http://access.bl.uk/item/share/ark:/81055/vdc_100082592360.0x000002",
+      "type": "Service",
+      "profile": "http://universalviewer.io/share-extensions-profile"
+    }
+  ],
+  "accompanyingCanvas": {
+    "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/c/poster",
+    "type": "Canvas",
+    "label": {
+      "en": ["world"]
+    },
+    "width": 962,
+    "height": 962,
+    "items": [
+      {
+        "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/c/a1",
+        "type": "AnnotationPage",
+        "items": [
+          {
+            "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/c/a1/a1",
+            "type": "Annotation",
+            "motivation": "painting",
+            "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/c/poster",
+            "body": {
+              "id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/posters/world.jpg",
+              "type": "Image",
+              "width": 962,
+              "height": 962,
+              "format": "image/jpeg"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "homepage": [
+    {
+      "id": "http://access.bl.uk/item/viewer/ark:/81055/vdc_100082592360.0x000002",
+      "type": "Text",
+      "format": "text/html",
+      "label": {
+        "en": ["View at the British Library"]
+      }
+    }
+  ],
+  "behavior": ["auto-advance"],
+  "items": [
+    {
+      "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004",
+      "type": "Canvas",
+      "label": {
+        "en": ["Tape 1 Side 1"]
+      },
+      "duration": 1417.56,
+      "items": [
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004/anno1",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004/anno1/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=0,1417.56",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x00002f/manifest.mpd",
+                    "format": "application/dash+xml",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/dash/ark:/81055/vdc_100082592360.0x00002f/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x00002f/index.m3u8",
+                    "format": "vnd.apple.mpegURL",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/hls/ark:/81055/vdc_100082592360.0x00002f/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "seeAlso": [
+                {
+                  "id": "https://iiif-waveforms.s3.amazonaws.com/vdc_100082592360.0x00002e.dat",
+                  "type": "Dataset",
+                  "format": "application/octet-stream",
+                  "profile": "http://waveform.prototyping.bbc.co.uk"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006",
+      "type": "Canvas",
+      "label": {
+        "en": ["Tape 2 Side 1"]
+      },
+      "duration": 1520.04,
+      "items": [
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006/anno2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006/anno2/1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=0,378.72",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x000031/manifest.mpd",
+                    "format": "application/dash+xml",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/dash/ark:/81055/vdc_100082592360.0x000031/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x000031/index.m3u8",
+                    "format": "vnd.apple.mpegURL",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/hls/ark:/81055/vdc_100082592360.0x000031/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "seeAlso": [
+                {
+                  "id": "https://iiif-waveforms.s3.amazonaws.com/vdc_100082592360.0x000030.dat",
+                  "type": "Dataset",
+                  "format": "application/octet-stream",
+                  "profile": "http://waveform.prototyping.bbc.co.uk"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006/anno2/2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=378.72,1374.4",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x000033/manifest.mpd",
+                    "format": "application/dash+xml",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/dash/ark:/81055/vdc_100082592360.0x000033/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x000033/index.m3u8",
+                    "format": "vnd.apple.mpegURL",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/hls/ark:/81055/vdc_100082592360.0x000033/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "seeAlso": [
+                {
+                  "id": "https://iiif-waveforms.s3.amazonaws.com/vdc_100082592360.0x000032.dat",
+                  "type": "Dataset",
+                  "format": "application/octet-stream",
+                  "profile": "http://waveform.prototyping.bbc.co.uk"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006/anno2/3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "target": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1374.4,1520.04",
+              "body": {
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x000035/manifest.mpd",
+                    "format": "application/dash+xml",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/dash/ark:/81055/vdc_100082592360.0x000035/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "https://api.bl.uk/media/iiif/ark:/81055/vdc_100082592360.0x000035/index.m3u8",
+                    "format": "vnd.apple.mpegURL",
+                    "type": "Sound",
+                    "service": [
+                      {
+                        "id": "https://api.bl.uk/media/hls/ark:/81055/vdc_100082592360.0x000035/probe.json",
+                        "type": "AuthProbeService1",
+                        "profile": "http://iiif.io/api/auth/1/probe"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "seeAlso": [
+                {
+                  "id": "https://iiif-waveforms.s3.amazonaws.com/vdc_100082592360.0x000034.dat",
+                  "type": "Dataset",
+                  "format": "application/octet-stream",
+                  "profile": "http://waveform.prototyping.bbc.co.uk"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "structures": [
+    {
+      "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/top",
+      "type": "Range",
+      "label": {
+        "en": ["Wiltshire and Dorset, dub of disks / Fanny Rumble, A. Collins, Perrier (01:07:55)"]
+      },
+      "metadata": [
+        {
+          "label": {
+            "en": ["Full title"]
+          },
+          "value": {
+            "en": ["Wiltshire and Dorset, dub of disks / Fanny Rumble, A. Collins, Perrier"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Collection"]
+          },
+          "value": {
+            "en": ["Peter Kennedy Collection"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Format"]
+          },
+          "value": {
+            "en": ["1 tape reel 18 cm 19 cm/sec 1 tape reel 18 cm 19 cm/sec and 38 cm/sec"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Usage"]
+          },
+          "value": {
+            "en": ["<span>Rights unassigned - staff access only</span>"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Held by"]
+          },
+          "value": {
+            "en": ["The British Library"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Digitised by"]
+          },
+          "value": {
+            "en": ["The British Library, 2018"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Digitisation funded by"]
+          },
+          "value": {
+            "en": [
+              "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+            ]
+          }
+        },
+        {
+          "label": {
+            "en": ["Identifier"]
+          },
+          "value": {
+            "en": ["C604/16-C604/17"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Shelfmark"]
+          },
+          "value": {
+            "en": ["C604/16", "C604/17"]
+          }
+        },
+        {
+          "label": {
+            "en": ["Link to catalogue"]
+          },
+          "value": {
+            "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA7608156'>View the catalogue record</a>"]
+          }
+        }
+      ],
+      "requiredStatement": {
+        "label": {
+          "en": ["Usage"]
+        },
+        "value": {
+          "en": [
+            "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA7608156\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+          ]
+        }
+      },
+      "rendering": [
+        {
+          "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000002/top",
+          "type": "Audio",
+          "label": {
+            "en": ["Download this recording"]
+          },
+          "format": "audio/mp4"
+        }
+      ],
+      "items": [
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000007",
+          "type": "Range",
+          "label": {
+            "en": ["The turmut hoeing (02:29)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["The turmut hoeing"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": ["Perrier, Fred (singer, male)", "unidentified (singers)", "Kennedy, Peter, (sound recordist)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["2 min. 29 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["Accents and dialects - English language - England: Wiltshire"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C1"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176753'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "This song is also known by the title 'The vly on the turmut'.",
+                  "Dubbed from BBC 78 rpm disc 21493. For another dubbing from the same source see C604/26.",
+                  "Fred Perrier introduces the song and then proceeds to sing it.",
+                  "Preceded by talk."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176753\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000007",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=0,148.76",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000007/nn2",
+          "type": "Range",
+          "behavior": ["no-nav"],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=148.76,148.8",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000009",
+          "type": "Range",
+          "label": {
+            "en": ["She stole my heart away (02:08)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["She stole my heart away"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": ["Perrier, Fred (singer, male)", "Kennedy, Peter, (sound recordist)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["2 min. 07 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["Accents and dialects - English language - England: Wiltshire"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C2"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176766'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "Dubbed from BBC 78 rpm disc 21493. For another dubbing from the same source see C604/26.",
+                  "This song is also known by the title 'Twas on a Monday morning'.",
+                  "Preceded by talk."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176766\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000009",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=148.8,276.64",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00000b",
+          "type": "Range",
+          "label": {
+            "en": ["Dumble dum dollicky (Richard of Taunton Dean) (03:01)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["Dumble dum dollicky (Richard of Taunton Dean)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": ["Rumble, Fanny (singer, female)", "Kennedy, Peter, (sound recordist)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["3 min. 00 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["English"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C3"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176767'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": ["Dubbed from BBC 78 rpm disc 21494."]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176767\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00000b",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=276.64,458",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00000d",
+          "type": "Range",
+          "label": {
+            "en": ["Mrs Fanny Rumble talks about herself (01:44)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["Mrs Fanny Rumble talks about herself"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": ["Rumble, Fanny (speaker, female)", "Kennedy, Peter, (sound recordist / speaker, male)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["1 min. 44 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["Accents and dialects - English language - England: Wiltshire"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C4"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176768'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "Dubbed from BBC 78 rpm disc 21494.",
+                  "Fanny Rumble talks about where she learnt the songs she knows, and about her father and her husband."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176768\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00000d",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=458,562.4",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00000f",
+          "type": "Range",
+          "label": {
+            "en": ["What shall I wear to the wedding, John? (03:25)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["What shall I wear to the wedding, John?"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": [
+                  "Rumble, Fanny (singer, female)",
+                  "Collins, Albert (folk singer) (singer, male)",
+                  "Kennedy, Peter, (sound recordist)"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["3 min. 24 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["English"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C5"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176769'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "Dubbed from BBC 78 rpm disc 21493.",
+                  "A duet in dialogue form between a fictional soon-to-be-married couple."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176769\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00000f",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=562.4,767.24",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000011",
+          "type": "Range",
+          "label": {
+            "en": ["Country courtship (05:50)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["Country courtship"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": [
+                  "Cox, Edwin 'Ned' (speaker and singer, male)",
+                  "Stephens, Harry (folk musician) (speaker and singer, male)",
+                  "Kennedy, Peter, (sound recordist)"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-08 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Wool, Dorset, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["5 min. 50 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["Accents and dialects - English language - England: Dorset"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C6"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176770'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "Dubbed from BBC 78 rpm discs 21496-7.",
+                  "A courtship song between a lady from London and a man from the country; performed by two men. During the introductory talk the two performers recount how both they and their uncles before them used to publicly perform this song in full costume.",
+                  "Preceded by a few seconds of silence and short talk."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176770\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000011",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=767.24,1117.28",
+              "type": "Canvas"
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000013",
+          "type": "Range",
+          "label": {
+            "en": ["Herbert Prince (05:00)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["Herbert Prince"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": [
+                  "Prince, Herbert (speaker and singer, male)",
+                  "Kennedy, Peter, (sound recordist / speaker, male)"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Warminster, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["5 min. 00 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["Accents and dialects - English language - England: Wiltshire"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/16 C7-8"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/16"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176833'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "Individual items listed separately.",
+                  "Dubbed from BBC 78 rpm discs 21497 and 21474.",
+                  "Herbert Prince talks about learning the song 'The young sailor cut down in his prime', then proceeds to sing it. This is followed by a fragment of Prince talking about a song he used to sing on Shrove Tuesday as a child.",
+                  "Some crackle, increasing towards the end of the recording."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176833\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000013",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000013/nn1",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=1117.28,1119.76",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000014",
+              "type": "Range",
+              "label": {
+                "en": ["Introductory talk: 'The young sailor cut down in his prime' (01:25)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["Introductory talk: 'The young sailor cut down in his prime'"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": ["Prince, Herbert (speaker, male)", "Kennedy, Peter, (sound recordist / speaker, male)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Warminster, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["1 min. 25 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/16 C7"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/16"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176825'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "Dubbed from BBC 78 rpm disc 21497.",
+                      "Herbert Prince talks about learning the song 'The young sailor cut down in his prime' from his grandfather."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176825\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000014",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=1119.76,1204.96",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000014/nn2",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=1204.96,1209.4",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000015",
+              "type": "Range",
+              "label": {
+                "en": ["The young sailor cut down in his prime (02:49)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["The young sailor cut down in his prime"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": ["Prince, Herbert (singer, male)", "Kennedy, Peter, (sound recordist)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Warminster, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["2 min. 48 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["English"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/16 C8"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/16"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176829'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": ["Dubbed from BBC 78 rpm disc 21497."]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8176829\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000015",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=1209.4,1377.96",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000013/nn2",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000004#t=1377.96,1417.56",
+                  "type": "Canvas"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000019",
+          "type": "Range",
+          "label": {
+            "en": ["Fanny Rumble / Albert Collins / Fred Perrier (25:17)"]
+          },
+          "metadata": [
+            {
+              "label": {
+                "en": ["Full title"]
+              },
+              "value": {
+                "en": ["Fanny Rumble / Albert Collins / Fred Perrier"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Creator"]
+              },
+              "value": {
+                "en": [
+                  "Rumble, Fanny (singer and speaker, female)",
+                  "Collins, Albert (folk singer) (singer, male)",
+                  "Perrier, Fred (singer and speaker, male)",
+                  "Jenkins, Ioan (fiddle)",
+                  "Kennedy, Peter, (sound recordist / speaker, male)"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Date"]
+              },
+              "value": {
+                "en": ["1954-10-06 (recorded)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Place of creation"]
+              },
+              "value": {
+                "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Duration"]
+              },
+              "value": {
+                "en": ["25 min. 20 sec."]
+              }
+            },
+            {
+              "label": {
+                "en": ["Language"]
+              },
+              "value": {
+                "en": ["English"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Collection"]
+              },
+              "value": {
+                "en": ["Peter Kennedy Collection"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Usage"]
+              },
+              "value": {
+                "en": ["<span>Rights unassigned - staff access only</span>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Held by"]
+              },
+              "value": {
+                "en": ["The British Library"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitised by"]
+              },
+              "value": {
+                "en": ["The British Library, 2018"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Digitisation funded by"]
+              },
+              "value": {
+                "en": [
+                  "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                ]
+              }
+            },
+            {
+              "label": {
+                "en": ["Identifier"]
+              },
+              "value": {
+                "en": ["C604/17 C1-C8"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Shelfmark"]
+              },
+              "value": {
+                "en": ["C604/17"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Link to catalogue"]
+              },
+              "value": {
+                "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177150'>View the catalogue record</a>"]
+              }
+            },
+            {
+              "label": {
+                "en": ["Description"]
+              },
+              "value": {
+                "en": [
+                  "Individual items listed separately.",
+                  "A recording session in Tilshead, Wiltshire, with Fanny Rumble, Albert Collins and Fred Perrier. Some of the songs recorded for filming.",
+                  "Fanny Rumble and Albert Collins sing 'O what shall I wear to the wedding, John?' [two takes, the second of which was filmed with fiddle accompaniment].",
+                  "Fred Perrier sings 'The vly on the turmut' [two takes, the second of which was filmed] and 'Twas on a Monday morning' [two takes].",
+                  "Fanny Rumble sings 'Dumble dum dollicky' and then talks about herself, her father and her husband.",
+                  "Breaks and silences in the recording between individual tracks.",
+                  "Introduced by a short talk by Fanny Rumble."
+                ]
+              }
+            }
+          ],
+          "requiredStatement": {
+            "label": {
+              "en": ["Usage"]
+            },
+            "value": {
+              "en": [
+                "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177150\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+              ]
+            }
+          },
+          "rendering": [
+            {
+              "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000019",
+              "type": "Audio",
+              "label": {
+                "en": ["Download this recording"]
+              },
+              "format": "audio/mp4"
+            }
+          ],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000019/nn1",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=0,28.04",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001a",
+              "type": "Range",
+              "label": {
+                "en": ["O what shall I wear to the wedding, John? (03:57)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["O what shall I wear to the wedding, John?"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": [
+                      "Rumble, Fanny (singer, female)",
+                      "Collins, Albert (folk singer) (singer, male)",
+                      "Kennedy, Peter, (sound recordist / speaker, male)"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["3 min. 58 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["English"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C1"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177128'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": ["Preceded by talk."]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177128\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00001a",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=406.76000000000005,644.12",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001a/nn2",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=644.12,718.6400000000001",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001b",
+              "type": "Range",
+              "label": {
+                "en": ["O what shall I wear to the wedding, John? (02:47)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["O what shall I wear to the wedding, John?"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": [
+                      "Rumble, Fanny (singer, female)",
+                      "Collins, Albert (folk singer) (singer, male)",
+                      "Jenkins, Ioan (fiddle)",
+                      "Kennedy, Peter, (sound recordist)"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["2 min. 47 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["English"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C2"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177132'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "Note on original tape box says this song was recorded for filming ('Rumble 1').",
+                      "A duet between a fictional soon-to-be-married couple, performed for filming.",
+                      "Inconsistent speed due to wow and flutter issues on original tape."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177132\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00001b",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=718.6400000000001,885.52",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001b/nn3",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=885.52,885.6",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001c",
+              "type": "Range",
+              "label": {
+                "en": ["The vly on the turmut (03:10)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["The vly on the turmut"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": [
+                      "Perrier, Fred (singer, male)",
+                      "unidentified (singers)",
+                      "Kennedy, Peter, (sound recordist)"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["3 min. 10 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C3"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177136'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "This song is also known by the title 'The turmut hoeing'.",
+                      "Note on original tape box says this song was 'not filmed'.",
+                      "Fred Perrier introduces the song and then proceeds to sing it."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177136\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00001c",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=885.6,1075.6",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001c/nn4",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1075.6,1148.8000000000002",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001d",
+              "type": "Range",
+              "label": {
+                "en": ["The vly on the turmut (01:37)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["The vly on the turmut"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": [
+                      "Perrier, Fred (singer, male)",
+                      "unidentified (singers)",
+                      "Kennedy, Peter, (sound recordist)"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["1 min. 37 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C4"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177139'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "This song is also known by the title 'The turmut hoeing'.",
+                      "Note on original tape box says this song was filmed for the film 'Rumble 1'.",
+                      "Fred Perrier introduces the song and then proceeds to sing it."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177139\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00001d",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1148.8000000000002,1245.68",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001d/nn5",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1245.68,1250.72",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001e",
+              "type": "Range",
+              "label": {
+                "en": ["Twas on a Monday morning (02:04)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["Twas on a Monday morning"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": ["Perrier, Fred (singer, male)", "Kennedy, Peter, (sound recordist / speaker, male)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["2 min. 08 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C5"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177140'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "This song is also known by the title 'She stole my heart away'.",
+                      "Fred Perrier introduces the song and then proceeds to sing it.",
+                      "Distortion and inconsistent speed due to wow and flutter issues on original tape."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177140\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00001e",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1250.72,1374.4",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001e/nn6",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1374.4,1376.2",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x00001f",
+              "type": "Range",
+              "label": {
+                "en": ["Twas on a Monday morning (02:22)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["Twas on a Monday morning"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": ["Perrier, Fred (singer, male)", "Kennedy, Peter, (sound recordist / speaker, male)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["2 min. 22 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C6"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177149'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "This song is also known by the title 'She stole my heart away'.",
+                      "Fred Perrier introduces the song and then proceeds to sing it. At the end, he repeats the last verse of the song, because he sang the wrong lyrics the first time around.",
+                      "Distortion and inconsistent speed due to wow and flutter issues on original tape."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177149\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x00001f",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1376.2,1518.44",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000020",
+              "type": "Range",
+              "label": {
+                "en": ["Dumble dum dollicky (04:23)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["Dumble dum dollicky"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": ["Rumble, Fanny (singer, female)", "Kennedy, Peter, (sound recordist / speaker, male)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["2 min. 08 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C7"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177146'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "Fanny Rumble [also noted by recordist as 'Aunt Fanny'] introduces the song and then proceeds to sing it.",
+                      "False start at the beginning, followed by the complete version of the song.",
+                      "Some tape print-through, resulting in an echo-like effect before or after louder passages."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177146\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000020",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=1.84,264.64",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000020/nn8",
+              "type": "Range",
+              "behavior": ["no-nav"],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=264.64,266.08",
+                  "type": "Canvas"
+                }
+              ]
+            },
+            {
+              "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000021",
+              "type": "Range",
+              "label": {
+                "en": ["Talk about herself (01:53)"]
+              },
+              "metadata": [
+                {
+                  "label": {
+                    "en": ["Full title"]
+                  },
+                  "value": {
+                    "en": ["Talk about herself"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Creator"]
+                  },
+                  "value": {
+                    "en": ["Rumble, Fanny (speaker, female)", "Kennedy, Peter, (sound recordist / speaker, male)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Date"]
+                  },
+                  "value": {
+                    "en": ["1954-10-06 (recorded)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Place of creation"]
+                  },
+                  "value": {
+                    "en": ["Tilshead, Shrewton, Wiltshire, England, UK (recorded)", "England (place of origin)"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Duration"]
+                  },
+                  "value": {
+                    "en": ["1 min. 52 sec."]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Language"]
+                  },
+                  "value": {
+                    "en": ["Accents and dialects - English language - England: Wiltshire"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Collection"]
+                  },
+                  "value": {
+                    "en": ["Peter Kennedy Collection"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Usage"]
+                  },
+                  "value": {
+                    "en": ["<span>Rights unassigned - staff access only</span>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Held by"]
+                  },
+                  "value": {
+                    "en": ["The British Library"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitised by"]
+                  },
+                  "value": {
+                    "en": ["The British Library, 2018"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Digitisation funded by"]
+                  },
+                  "value": {
+                    "en": [
+                      "<span>National Lottery Heritage Fund<br><br><img src='https://www.heritagefund.org.uk/sites/default/files/media/attachments/TNLHLF_Colour_Logo_English_RGB_0_0.jpg'/></span>"
+                    ]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Identifier"]
+                  },
+                  "value": {
+                    "en": ["C604/17 C8"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Shelfmark"]
+                  },
+                  "value": {
+                    "en": ["C604/17"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Link to catalogue"]
+                  },
+                  "value": {
+                    "en": ["<a href='http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177148'>View the catalogue record</a>"]
+                  }
+                },
+                {
+                  "label": {
+                    "en": ["Description"]
+                  },
+                  "value": {
+                    "en": [
+                      "Fanny Rumble talks about where she learnt the songs she recorded on the day, and about her father and her husband."
+                    ]
+                  }
+                }
+              ],
+              "requiredStatement": {
+                "label": {
+                  "en": ["Usage"]
+                },
+                "value": {
+                  "en": [
+                    "<span><a href=\"http://explore.bl.uk/BLVU1:LSCOP-ALL:BLLSA8177148\">Please read the full information about this object</a><br>Rights unassigned - staff access only</span>"
+                  ]
+                }
+              },
+              "rendering": [
+                {
+                  "id": "https://api.bl.uk/item/download/ark:/81055/vdc_100082592360.0x000002/ark:/81055/vdc_100082592360.0x000021",
+                  "type": "Audio",
+                  "label": {
+                    "en": ["Download this recording"]
+                  },
+                  "format": "audio/mp4"
+                }
+              ],
+              "items": [
+                {
+                  "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000006#t=266.08,378.72",
+                  "type": "Canvas"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100082592360.0x000002/top/nn8",
+          "type": "Range",
+          "behavior": ["no-nav"],
+          "items": [
+            {
+              "id": "https://api.bl.uk/metadata/iiif/#t=378.72,1520.04",
+              "type": "Canvas"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/ranges.ts
+++ b/src/ranges.ts
@@ -1,6 +1,8 @@
-import { Reference } from '@iiif/presentation-3';
+import { Range, InternationalString, Reference, SpecificResource } from '@iiif/presentation-3';
 import { ManifestNormalized, RangeNormalized } from '@iiif/presentation-3-normalized';
 import { CompatVault, compatVault } from './compat';
+import { compressSpecificResource } from '@iiif/parser';
+import { hash } from './shared-utilities';
 
 export function createRangeHelper(vault: CompatVault = compatVault) {
   return {
@@ -9,11 +11,21 @@ export function createRangeHelper(vault: CompatVault = compatVault) {
     findManifestSelectedRange: (manifest: ManifestNormalized, canvasId: string) =>
       findManifestSelectedRange(vault, manifest, canvasId),
     findSelectedRange: (range: RangeNormalized, canvasId: string) => findSelectedRange(vault, range, canvasId),
+    rangesToTableOfContentsTree: (rangeRefs: RangeNormalized[], label?: InternationalString | null) =>
+      rangesToTableOfContentsTree(vault, rangeRefs, label),
+    rangeToTableOfContentsTree: (rangeRef: RangeNormalized | Reference<'Range'>) =>
+      rangeToTableOfContentsTree(vault, rangeRef),
   };
 }
 
 export function findFirstCanvasFromRange(vault: CompatVault, range: RangeNormalized): null | Reference<'Canvas'> {
   for (const inner of range.items) {
+    if (typeof inner === 'string') {
+      return { id: inner, type: 'Canvas' };
+    }
+    if ((inner as any).type === 'Canvas') {
+      return inner as any as Reference<'Canvas'>;
+    }
     if (inner.type === 'SpecificResource') {
       if (inner.source?.type === 'Canvas') {
         return inner.source as Reference<'Canvas'>;
@@ -29,20 +41,48 @@ export function findFirstCanvasFromRange(vault: CompatVault, range: RangeNormali
   return null;
 }
 
+export function findFirstCanvasFromRangeWithSelector(
+  vault: CompatVault,
+  range: RangeNormalized
+): null | SpecificResource<Reference<'Canvas'>> {
+  for (const inner of range.items) {
+    if (typeof inner === 'string') {
+      return { type: 'SpecificResource', source: { id: inner, type: 'Canvas' } as Reference<'Canvas'> };
+    }
+    if ((inner as any).type === 'Canvas') {
+      return { type: 'SpecificResource', source: inner as any as Reference<'Canvas'> };
+    }
+    if (inner.type === 'SpecificResource') {
+      if (inner.source?.type === 'Canvas') {
+        return inner as SpecificResource<Reference<'Canvas'>>;
+      }
+    }
+    if (inner.type === 'Range') {
+      const found = findFirstCanvasFromRangeWithSelector(vault, vault.get(inner));
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+}
+
 export function findAllCanvasesInRange(vault: CompatVault, range: RangeNormalized): Array<Reference<'Canvas'>> {
   const found: Reference<'Canvas'>[] = [];
   for (const inner of range.items) {
-    if (inner.type === 'SpecificResource') {
-      if (inner.source?.type === 'Canvas') {
-        if (inner.source.id.indexOf('#') !== -1) {
-          found.push({ id: inner.source.id.split('#')[0], type: 'Canvas' });
-        } else {
-          found.push(inner.source as Reference<'Canvas'>);
-        }
+    if (inner.type === 'SpecificResource' && inner.source?.type === 'Canvas') {
+      if (inner.source.id.indexOf('#') !== -1) {
+        found.push({ id: inner.source.id.split('#')[0], type: 'Canvas' });
+      } else {
+        found.push(inner.source as Reference<'Canvas'>);
       }
     }
     if (inner.type === 'Range') {
       found.push(...findAllCanvasesInRange(vault, vault.get(inner)));
+    }
+    if ((inner as any).type === 'SpecificResource') {
+      const sourceId = typeof (inner as any).source === 'string' ? (inner as any).source : (inner as any).source.id;
+      found.push({ id: sourceId, type: 'Canvas' });
     }
   }
   return found;
@@ -69,7 +109,11 @@ export function findSelectedRange(
   canvasId: string
 ): null | RangeNormalized {
   for (const inner of range.items) {
+    const parsedId = (inner as any)?.source?.id?.split('#')[0];
     if ((inner as any).type === 'SpecificResource' && (inner as any).source === canvasId) {
+      return range;
+    }
+    if (inner.type === 'SpecificResource' && inner.source?.type === 'Canvas' && canvasId === parsedId) {
       return range;
     }
     if (inner.type === 'Range') {
@@ -80,4 +124,156 @@ export function findSelectedRange(
     }
   }
   return null;
+}
+
+export interface RangeTableOfContentsNode {
+  id: string;
+  type: 'Canvas' | 'Range';
+  label: InternationalString | null;
+  resource?: SpecificResource;
+  untitled?: boolean;
+  isCanvasLeaf: boolean;
+  isRangeLeaf: boolean;
+  isVirtual?: boolean;
+  firstCanvas?: SpecificResource<Reference<'Canvas'>> | null;
+  items?: Array<RangeTableOfContentsNode>;
+}
+
+export function rangesToTableOfContentsTree(
+  vault: CompatVault,
+  rangeRefs: RangeNormalized[] | Range[] | Reference<'Range'>[],
+  label?: InternationalString | null
+): RangeTableOfContentsNode | null {
+  if (rangeRefs.length === 0) {
+    return null;
+  }
+
+  const ranges = vault.get(rangeRefs);
+
+  if (ranges.length === 1) {
+    return rangeToTableOfContentsTree(vault, ranges[0] as any);
+  }
+
+  const virtualRoot: Range = {
+    id: `vault://virtual-root/${hash(ranges)}`,
+    type: 'Range',
+    label: label || { en: ['Table of Contents'] },
+    items: ranges as any,
+  };
+
+  return rangeToTableOfContentsTree(vault, virtualRoot);
+}
+
+export function rangeToTableOfContentsTree(
+  vault: CompatVault,
+  rangeRef: undefined | null | Range | RangeNormalized | Reference<'Range'>,
+  seenIds: string[] = []
+): RangeTableOfContentsNode | null {
+  if (!rangeRef) return null;
+
+  const range = vault.get(rangeRef, { skipSelfReturn: false });
+  const toc: RangeTableOfContentsNode = {
+    id: range.id,
+    type: 'Range',
+    label: range.label,
+    untitled: !range.label,
+    isCanvasLeaf: false,
+    isRangeLeaf: false,
+    items: [],
+  };
+
+  if (seenIds.indexOf(toc.id) !== -1) {
+    toc.id = `vault://${hash(range)}`;
+  }
+
+  if (!range.items) {
+    return toc;
+  }
+
+  if (range.behavior && range.behavior.includes('no-nav')) {
+    return null;
+  }
+
+  for (const inner of range.items) {
+    if (typeof inner === 'string') {
+      const maybeCanvas = vault.get({ id: inner, type: 'Canvas' }, { skipSelfReturn: false });
+      const foundCanvas: RangeTableOfContentsNode = {
+        id: inner,
+        type: 'Canvas',
+        isCanvasLeaf: true,
+        isRangeLeaf: false,
+        label: maybeCanvas.label || { none: ['Untitled'] },
+        untitled: !maybeCanvas.label,
+        resource: {
+          type: 'SpecificResource',
+          source: { id: inner, type: 'Canvas' },
+        },
+      };
+
+      if (seenIds.indexOf(foundCanvas.id) !== -1) {
+        foundCanvas.id = `vault://${hash(inner)}`;
+      }
+
+      seenIds.push(foundCanvas.id);
+      continue;
+    }
+    if (inner.type === 'SpecificResource' && inner.source?.type === 'Canvas') {
+      const maybeCanvas = vault.get(inner.source);
+      const compressed = compressSpecificResource(inner);
+
+      if (!maybeCanvas) {
+        continue;
+      }
+
+      const foundCanvas: RangeTableOfContentsNode = {
+        id: compressed.type === 'Canvas' ? compressed.id : inner.source.id,
+        type: 'Canvas',
+        isCanvasLeaf: true,
+        isRangeLeaf: false,
+        label: maybeCanvas.label || { none: ['Untitled'] },
+        untitled: !maybeCanvas.label,
+        resource: inner,
+      };
+      if (seenIds.indexOf(foundCanvas.id) !== -1) {
+        foundCanvas.id = `vault://${hash(inner)}`;
+      }
+
+      seenIds.push(foundCanvas.id);
+
+      toc.items!.push(foundCanvas);
+      continue;
+    }
+    if ((inner as any).type === 'Canvas') {
+      const foundCanvas: RangeTableOfContentsNode = {
+        id: (inner as any).id,
+        type: 'Canvas',
+        label: (inner as any).label,
+        isCanvasLeaf: true,
+        isRangeLeaf: false,
+        resource: {
+          type: 'SpecificResource',
+          source: inner as any,
+        },
+      };
+
+      if (seenIds.indexOf(foundCanvas.id) !== -1) {
+        foundCanvas.id = `vault://${hash(inner)}`;
+      }
+
+      seenIds.push(foundCanvas.id);
+      continue;
+    }
+    if ((inner as any).type === 'Range') {
+      const foundRange = rangeToTableOfContentsTree(vault, inner as any, seenIds);
+      if (foundRange) {
+        toc.items!.push(foundRange);
+      }
+      continue;
+    }
+  }
+
+  toc.firstCanvas = findFirstCanvasFromRangeWithSelector(vault, range);
+  toc.isRangeLeaf = toc.items ? toc.items.filter((i) => i.type === 'Range').length === 0 : true;
+
+  return toc;
 }

--- a/src/shared-utilities.ts
+++ b/src/shared-utilities.ts
@@ -1,0 +1,22 @@
+/**
+ * A string hashing function based on Daniel J. Bernstein's popular 'times 33' hash algorithm.
+ * @author MatthewBarker <mrjbarker@hotmail.com>
+ */
+export function hash(object: any): string {
+  const text = JSON.stringify(object);
+
+  let numHash = 5381,
+    index = text.length;
+
+  while (index) {
+    numHash = (numHash * 33) ^ text.charCodeAt(--index);
+  }
+
+  const num = numHash >>> 0;
+
+  const hexString = num.toString(16);
+  if (hexString.length % 2) {
+    return '0' + hexString;
+  }
+  return hexString;
+}


### PR DESCRIPTION
Currently this will produce a tree with two types of node.

Full interface:
```ts
interface RangeTableOfContentsNode {
  id: string;
  type: 'Canvas' | 'Range';
  label: InternationalString | null;
  resource?: SpecificResource;
  untitled?: boolean;
  isCanvasLeaf: boolean;
  isRangeLeaf: boolean;
  isVirtual?: boolean;
  firstCanvas?: SpecificResource<Reference<'Canvas'>> | null;
  items?: Array<RangeTableOfContentsNode>;
}
```

Example Range node:
```json
{
  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/range/r1",
  "type": "Range",
  "isCanvasLeaf": false,
  "isRangeLeaf": true,
  "label": {
    "gez": [
      "Tabiba Tabiban [ጠቢበ ጠቢባን]",
    ],
  },
  "untitled": false,
  "firstCanvas": {
    "source": {
      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p1",
      "type": "Canvas",
    },
    "type": "SpecificResource",
  },
  "items": [ ... ],
}
```

The "Range" node contains the following:
- `isRangeLeaf`: if this range _only_ contains canvases
- `label`: from the range itself, will be `"Untitled"` if not found
- `untitled`: boolean, if it is untitled (for display)
- `firstCanvas`: SpecificResource with optional selector of the first canvas, for navigation.
- `items`: list of items inside the range.

Example Canvas node:
```json
 {
  "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
  "isCanvasLeaf": true,
  "isRangeLeaf": false,
  "label": {
    "en": [
      "f. 1v",
    ],
  },
  "resource": {
    "source": {
      "id": "https://iiif.io/api/cookbook/recipe/0024-book-4-toc/canvas/p2",
      "type": "Canvas",
    },
    "type": "SpecificResource",
  },
  "type": "Canvas",
  "untitled": false,
}
```

Similar properties to the range, if you wanted to display each canvas. The label is grabbed from the canvas (if you use the helper with Vault). 

It will also work with AV or regions, and use the normalized "SpecificResource" format, to make it easier to use.
```json
{
  "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1#t=0,302.05",
  "isCanvasLeaf": true,
  "isRangeLeaf": false,
  "label": {
    "none": [
      "Untitled",
    ],
  },
  "resource": {
    "selector": {
      "type": "FragmentSelector",
      "value": "t=0,302.05",
    },
    "source": {
      "id": "https://iiif.io/api/cookbook/recipe/0026-toc-opera/canvas/1",
      "type": "Canvas",
    },
    "type": "SpecificResource",
  },
  "type": "Canvas",
  "untitled": true,
}
```
In this example, the canvas ID is pulled out, but the range is `Untitled` and marked as untitled. The time selector is also pulled out. (Other helpers in the repo can be used to parse it further).