### PR TITLE
Added nav date helper for navigating by date

### DIFF
--- a/__tests__/nav-date.tests.ts
+++ b/__tests__/nav-date.tests.ts
@@ -162,6 +162,140 @@ describe('nav-date helper', () => {
         Thu Jan 01 1987
           1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
       `);
+
+      // Final of the full count
+      expect(byCentury).toMatchInlineSnapshot(`
+        [
+          {
+            "count": 2,
+            "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/century/1900",
+            "items": [
+              {
+                "count": 2,
+                "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/decade/1980",
+                "items": [
+                  {
+                    "count": 1,
+                    "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/year/1986",
+                    "items": [
+                      {
+                        "count": 1,
+                        "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/month/0",
+                        "items": [
+                          {
+                            "count": 1,
+                            "day": 1,
+                            "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/day/1",
+                            "items": [
+                              {
+                                "count": 1,
+                                "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json",
+                                "label": {
+                                  "en": [
+                                    "1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
+                                  ],
+                                },
+                                "navDate": "1986-01-01T00:00:00+00:00",
+                                "type": "Manifest",
+                              },
+                            ],
+                            "label": {
+                              "en": [
+                                "Wed Jan 01 1986",
+                              ],
+                            },
+                            "type": "day",
+                          },
+                        ],
+                        "label": {
+                          "en": [
+                            "January",
+                          ],
+                        },
+                        "month": 0,
+                        "type": "month",
+                      },
+                    ],
+                    "label": {
+                      "en": [
+                        "1986",
+                      ],
+                    },
+                    "type": "year",
+                    "year": 1986,
+                  },
+                  {
+                    "count": 1,
+                    "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/year/1987",
+                    "items": [
+                      {
+                        "count": 1,
+                        "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/month/0",
+                        "items": [
+                          {
+                            "count": 1,
+                            "day": 1,
+                            "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/day/1",
+                            "items": [
+                              {
+                                "count": 1,
+                                "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json",
+                                "label": {
+                                  "en": [
+                                    "1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide",
+                                  ],
+                                },
+                                "navDate": "1987-01-01T00:00:00+00:00",
+                                "type": "Manifest",
+                              },
+                            ],
+                            "label": {
+                              "en": [
+                                "Thu Jan 01 1987",
+                              ],
+                            },
+                            "type": "day",
+                          },
+                        ],
+                        "label": {
+                          "en": [
+                            "January",
+                          ],
+                        },
+                        "month": 0,
+                        "type": "month",
+                      },
+                    ],
+                    "label": {
+                      "en": [
+                        "1987",
+                      ],
+                    },
+                    "type": "year",
+                    "year": 1987,
+                  },
+                ],
+                "label": {
+                  "en": [
+                    "1980 - 1989",
+                  ],
+                },
+                "type": "decade",
+                "yearEnd": 1989,
+                "yearStart": 1980,
+              },
+            ],
+            "label": {
+              "en": [
+                "1900 - 1999",
+              ],
+            },
+            "type": "century",
+            "yearEnd": 1999,
+            "yearStart": 1900,
+          },
+        ]
+      `);
     });
   });
 });

--- a/__tests__/nav-date.tests.ts
+++ b/__tests__/nav-date.tests.ts
@@ -1,0 +1,167 @@
+import { Collection } from '@iiif/presentation-3';
+import { createDateNavigation } from '../src/nav-date';
+import { Vault } from '../src';
+
+function renderTreeAsAscii(navDates: any[]) {
+  const lines: string[] = [];
+  for (const century of navDates) {
+    lines.push(`${century.label.en[0]}`);
+    if (!century.items) {
+      lines.push(`  ${century.label.en[0]}`);
+      continue;
+    }
+    for (const decade of century.items) {
+      if (!decade.items) {
+        lines.push(`  ${decade.label.en[0]}`);
+        continue;
+      }
+      lines.push(`  ${decade.label.en[0]}`);
+      for (const year of decade.items) {
+        if (!year.items) {
+          lines.push(`    ${year.label.en[0]}`);
+          continue;
+        }
+        lines.push(`    ${year.label.en[0]}`);
+        for (const month of year.items) {
+          if (!month.items) {
+            lines.push(`      ${month.label.en[0]}`);
+            continue;
+          }
+          lines.push(`      ${month.label.en[0]}`);
+          for (const day of month.items) {
+            if (!day.items) {
+              lines.push(`        ${day.label.en[0]}`);
+              continue;
+            }
+            lines.push(`        ${day.label.en[0]}`);
+            for (const item of day.items) {
+              if (!item.label) continue;
+              lines.push(`          ${item.label.en[0]} (${item.navDate})`);
+            }
+          }
+        }
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+describe('nav-date helper', () => {
+  describe('createDateNavigation', () => {
+    test('should create a navigation tree', () => {
+      const collection: Collection = {
+        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        id: 'https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json',
+        type: 'Collection',
+        label: {
+          en: ['Chesapeake and Ohio Canal map and guide pamphlets'],
+        },
+        thumbnail: [
+          {
+            id: 'https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674/full/max/0/default.jpg',
+            type: 'Image',
+            format: 'image/jpeg',
+            height: 300,
+            width: 221,
+            service: [
+              {
+                id: 'https://iiif.io/api/image/3.0/example/reference/43153e2ec7531f14dd1c9b2fc401678a-88695674',
+                profile: 'level1',
+                type: 'ImageService3',
+              },
+            ],
+          },
+        ],
+        items: [
+          {
+            id: 'https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json',
+            type: 'Manifest',
+            label: {
+              en: ['1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide'],
+            },
+            navDate: '1986-01-01T00:00:00+00:00',
+          },
+          {
+            id: 'https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json',
+            type: 'Manifest',
+            label: {
+              en: ['1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide'],
+            },
+            navDate: '1987-01-01T00:00:00+00:00',
+          },
+        ],
+      } as any;
+      const vault = new Vault();
+      const col = vault.loadSync(collection.id, collection);
+
+      const auto = createDateNavigation(vault, col as any);
+      expect(renderTreeAsAscii(auto)).toMatchInlineSnapshot(`
+        "1986
+          January
+            Wed Jan 01 1986
+              1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
+        1987
+          January
+            Thu Jan 01 1987
+              1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
+      `);
+
+      const byCentury = createDateNavigation(vault, col as any, 'century');
+      expect(renderTreeAsAscii(byCentury)).toMatchInlineSnapshot(`
+        "1900 - 1999
+          1980 - 1989
+            1986
+              January
+                Wed Jan 01 1986
+                  1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide (1986-01-01T00:00:00+00:00)
+            1987
+              January
+                Thu Jan 01 1987
+                  1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide (1987-01-01T00:00:00+00:00)"
+      `);
+
+      const byDecade = createDateNavigation(vault, col as any, 'decade');
+      expect(renderTreeAsAscii(byDecade)).toMatchInlineSnapshot(`
+        "1980 - 1989
+          1986
+            January
+              Wed Jan 01 1986
+                1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
+          1987
+            January
+              Thu Jan 01 1987
+                1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
+      `);
+
+      const byYear = createDateNavigation(vault, col as any, 'year');
+      expect(renderTreeAsAscii(byYear)).toMatchInlineSnapshot(`
+        "1986
+          January
+            Wed Jan 01 1986
+              1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
+        1987
+          January
+            Thu Jan 01 1987
+              1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
+      `);
+
+      const byMonth = createDateNavigation(vault, col as any, 'month');
+      expect(renderTreeAsAscii(byMonth)).toMatchInlineSnapshot(`
+        "January 1986
+          Wed Jan 01 1986
+            1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
+        January 1987
+          Thu Jan 01 1987
+            1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
+      `);
+
+      const byDay = createDateNavigation(vault, col as any, 'day');
+      expect(renderTreeAsAscii(byDay)).toMatchInlineSnapshot(`
+        "Wed Jan 01 1986
+          1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
+        Thu Jan 01 1987
+          1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
+      `);
+    });
+  });
+});

--- a/__tests__/nav-date.tests.ts
+++ b/__tests__/nav-date.tests.ts
@@ -188,7 +188,6 @@ describe('nav-date helper', () => {
                             "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/day/1",
                             "items": [
                               {
-                                "count": 1,
                                 "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_2-manifest.json",
                                 "label": {
                                   "en": [
@@ -238,7 +237,6 @@ describe('nav-date helper', () => {
                             "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate-collection.json/day/1",
                             "items": [
                               {
-                                "count": 1,
                                 "id": "https://iiif.io/api/cookbook/recipe/0230-navdate/navdate_map_1-manifest.json",
                                 "label": {
                                   "en": [

--- a/package.json
+++ b/package.json
@@ -128,6 +128,16 @@
         "default": "./dist/sequences.js"
       }
     },
+    "./nav-date": {
+      "require": {
+        "types": "./dist/nav-date.d.ts",
+        "default": "./dist/nav-date.cjs"
+      },
+      "import": {
+        "types": "./dist/nav-date.d.ts",
+        "default": "./dist/nav-date.js"
+      }
+    },
     "./vault": {
       "require": {
         "types": "./dist/vault.d.ts",

--- a/src/nav-date.ts
+++ b/src/nav-date.ts
@@ -11,7 +11,6 @@ import { CollectionNormalized, ManifestNormalized } from '@iiif/presentation-3-n
 interface DateNavigationResource {
   id: string;
   type: 'Manifest' | 'Canvas';
-  count: number;
   label: InternationalString;
   navDate: string;
 }
@@ -118,6 +117,8 @@ export function createDateNavigation<T extends DateNavigationTypes, Type = T['ty
           items.push(centuryItem as T);
         }
         centuries.push(centuryItem);
+      } else {
+        centuryItem.count++;
       }
 
       let decadeItem = centuryItem.items.find((i) => i.yearStart === decade);
@@ -135,6 +136,8 @@ export function createDateNavigation<T extends DateNavigationTypes, Type = T['ty
         if (type === 'decade') {
           items.push(decadeItem as T);
         }
+      } else {
+        decadeItem.count++;
       }
       let yearItem = decadeItem.items.find((i) => i.year === year);
       if (!yearItem) {
@@ -150,6 +153,8 @@ export function createDateNavigation<T extends DateNavigationTypes, Type = T['ty
         if (type === 'year') {
           items.push(yearItem as T);
         }
+      } else {
+        yearItem.count++;
       }
       let monthItem = yearItem.items.find((i) => i.month === month);
       if (!monthItem) {
@@ -172,6 +177,8 @@ export function createDateNavigation<T extends DateNavigationTypes, Type = T['ty
         if (type === 'month') {
           items.push(monthItem as T);
         }
+      } else {
+        monthItem.count++;
       }
       let dayItem = monthItem.items.find((i) => i.day === day);
       if (!dayItem) {
@@ -187,13 +194,14 @@ export function createDateNavigation<T extends DateNavigationTypes, Type = T['ty
         if (type === 'day') {
           items.push(dayItem as T);
         }
+      } else {
+        dayItem.count++;
       }
       dayItem.items.push({
         id: item.id,
         type: item.type as any,
         label: item.label || { en: [`${year}-${month + 1}-${day}`] },
         navDate: item.navDate,
-        count: 1,
       });
     }
   }

--- a/src/nav-date.ts
+++ b/src/nav-date.ts
@@ -1,0 +1,211 @@
+// Parse nav date fields and create a navigation tree.
+// Decades, years, months, and days are supported.
+// Manifests or Canvases can have a property like:
+// "navDate": "1986-01-01T00:00:00+00:00"
+// "navDate": "1987-01-01T00:00:00+00:00"
+
+import { Collection, InternationalString, Manifest } from '@iiif/presentation-3';
+import { CompatVault } from './compat';
+import { CollectionNormalized, ManifestNormalized } from '@iiif/presentation-3-normalized';
+
+interface DateNavigationResource {
+  id: string;
+  type: 'Manifest' | 'Canvas';
+  count: number;
+  label: InternationalString;
+  navDate: string;
+}
+
+interface DateNavigationDay {
+  id: string;
+  type: 'day';
+  count: number;
+  label: InternationalString;
+  day: number;
+  items: Array<DateNavigationResource>;
+}
+
+interface DateNavigationMonth {
+  id: string;
+  type: 'month';
+  month: number;
+  count: number;
+  label: InternationalString;
+  items: Array<DateNavigationDay>;
+}
+
+interface DateNavigationYear {
+  id: string;
+  type: 'year';
+  year: number;
+  count: number;
+  label: InternationalString;
+  items: Array<DateNavigationMonth>;
+}
+
+interface DateNavigationDecade {
+  id: string;
+  type: 'decade';
+  yearStart: number;
+  yearEnd: number;
+  label: InternationalString;
+  count: number;
+  items: Array<DateNavigationYear>;
+}
+
+interface DateNavigationCentury {
+  id: string;
+  type: 'century';
+  yearStart: number;
+  yearEnd: number;
+  label: InternationalString;
+  count: number;
+  items: Array<DateNavigationDecade>;
+}
+
+type DateNavigationTypes =
+  | DateNavigationCentury
+  | DateNavigationDecade
+  | DateNavigationYear
+  | DateNavigationMonth
+  | DateNavigationDay;
+
+export function createDateNavigation<T extends DateNavigationTypes, Type = T['type']>(
+  vault: CompatVault,
+  manifestOrCollection: Manifest | Collection | ManifestNormalized | CollectionNormalized | string,
+  inputType?: Type
+) {
+  const type = inputType || 'century';
+  const items: T[] = [];
+
+  const centuries: DateNavigationCentury[] = [];
+
+  const resource = vault.get<any>(manifestOrCollection) as {
+    label?: InternationalString;
+    id: string;
+    items: Array<{
+      id: string;
+      type: string;
+      label?: InternationalString;
+      navDate?: string;
+    }>;
+  };
+
+  if (!resource.items) {
+    return items;
+  }
+
+  for (const item of resource.items) {
+    if (item.navDate) {
+      const d = new Date(item.navDate);
+      const year = d.getFullYear();
+      const month = d.getMonth();
+      const day = d.getDate();
+      const decade = Math.floor(year / 10) * 10;
+      const century = Math.floor(year / 100) * 100;
+      let centuryItem = centuries.find((i) => i.yearStart === century);
+      if (!centuryItem) {
+        centuryItem = {
+          id: `${resource.id}/century/${century}`,
+          label: { en: [`${century} - ${century + 99}`] },
+          type: 'century',
+          yearStart: century,
+          yearEnd: century + 99,
+          count: 1,
+          items: [],
+        };
+        if (type === 'century') {
+          items.push(centuryItem as T);
+        }
+        centuries.push(centuryItem);
+      }
+
+      let decadeItem = centuryItem.items.find((i) => i.yearStart === decade);
+      if (!decadeItem) {
+        decadeItem = {
+          id: `${resource.id}/decade/${decade}`,
+          label: { en: [`${decade} - ${decade + 9}`] },
+          type: 'decade',
+          yearStart: decade,
+          yearEnd: decade + 9,
+          count: 1,
+          items: [],
+        };
+        centuryItem.items.push(decadeItem);
+        if (type === 'decade') {
+          items.push(decadeItem as T);
+        }
+      }
+      let yearItem = decadeItem.items.find((i) => i.year === year);
+      if (!yearItem) {
+        yearItem = {
+          id: `${resource.id}/year/${year}`,
+          label: { en: [`${year}`] },
+          type: 'year',
+          year: year,
+          count: 1,
+          items: [],
+        };
+        decadeItem.items.push(yearItem);
+        if (type === 'year') {
+          items.push(yearItem as T);
+        }
+      }
+      let monthItem = yearItem.items.find((i) => i.month === month);
+      if (!monthItem) {
+        monthItem = {
+          id: `${resource.id}/month/${month}`,
+          // Month as string
+          label: {
+            en: [
+              type === 'month'
+                ? `${d.toLocaleString('default', { month: 'long' })} ${year}`
+                : `${d.toLocaleString('default', { month: 'long' })}`,
+            ],
+          },
+          type: 'month',
+          month: month,
+          count: 1,
+          items: [],
+        };
+        yearItem.items.push(monthItem);
+        if (type === 'month') {
+          items.push(monthItem as T);
+        }
+      }
+      let dayItem = monthItem.items.find((i) => i.day === day);
+      if (!dayItem) {
+        dayItem = {
+          id: `${resource.id}/day/${day}`,
+          label: { en: [`${d.toDateString()}`] },
+          type: 'day',
+          day: day,
+          count: 1,
+          items: [],
+        };
+        monthItem.items.push(dayItem);
+        if (type === 'day') {
+          items.push(dayItem as T);
+        }
+      }
+      dayItem.items.push({
+        id: item.id,
+        type: item.type as any,
+        label: item.label || { en: [`${year}-${month + 1}-${day}`] },
+        navDate: item.navDate,
+        count: 1,
+      });
+    }
+  }
+
+  if (!inputType) {
+    // Filter until there's more than one per level.
+    let autoItem = items;
+    while (autoItem.length === 1) {
+      autoItem = autoItem[0].items as T[];
+    }
+    return autoItem;
+  }
+
+  return items;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig((options: Options) => ({
     'painting-annotations': 'src/painting-annotations.ts',
     ranges: 'src/ranges.ts',
     sequences: 'src/sequences.ts',
+    'nav-date': 'src/nav-date.ts',
     vault: 'src/vault.ts',
     'vault-node': 'src/vault-node.ts',
     'vault-store': 'src/vault-store.ts',


### PR DESCRIPTION
This will produce an object that can be used to create a tree for navigating by decade, year, month or day. It will also optionally choose the best one (based on the first divergence).

Parsing the [Cookbook example](https://iiif.io/api/cookbook/recipe/0230-navdate/) it can produce the following navigations:


Automatic choice:
```
1986
  January
    Wed Jan 01 1986
      1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
1987
  January
    Thu Jan 01 1987
      1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide"
```

By century:
```
1900 - 1999
  1980 - 1989
    1986
      January
        Wed Jan 01 1986
          1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide (1986-01-01T00:00:00+00:00)
    1987
      January
        Thu Jan 01 1987
          1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide (1987-01-01T00:00:00+00:00)"
```

By decade:
```
1980 - 1989
  1986
    January
      Wed Jan 01 1986
        1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
  1987
    January
      Thu Jan 01 1987
        1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
```

By year:
```
1986
  January
    Wed Jan 01 1986
      1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
1987
  January
    Thu Jan 01 1987
      1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
```

By month: (note, this adds year to the labels)
```
January 1986
  Wed Jan 01 1986
    1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
January 1987
  Thu Jan 01 1987
    1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
```

By day:
```
Wed Jan 01 1986
  1986 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
Thu Jan 01 1987
  1987 Chesapeake and Ohio Canal, Washington, D.C., Maryland, West Virginia, official map and guide
```

The tree structure includes some basic information for rendering:
```ts
type T = {
  id: string;
  type: 'day';
  count: number;
  label: InternationalString;
}
```

And then also numeric representations if you want to build your own labels (e.g. year, day, month numbers)

The final resource includes:
```ts
interface DateNavigationResource {
  id: string;
  type: 'Manifest' | 'Canvas';
  label: InternationalString;
  navDate: string;
}
```